### PR TITLE
Site improvement suggestions

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -71,6 +71,21 @@
 	border-bottom-color: var(--color-neutral-400);
 }
 
+@keyframes fade-in-up {
+	from {
+		opacity: 0;
+		transform: translateY(8px);
+	}
+	to {
+		opacity: 1;
+		transform: translateY(0);
+	}
+}
+
+.animate-fade-in-up {
+	animation: fade-in-up 0.4s ease-out;
+}
+
 .social-link svg {
 	transition:
 		transform 0.2s ease,

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -14,7 +14,7 @@
 	></div>
 
 	<div class="relative z-10 flex h-full w-full justify-center overflow-auto p-4 sm:p-8">
-		<div class="w-full max-w-2xl">
+		<div class="animate-fade-in-up w-full max-w-2xl">
 			{@render children()}
 		</div>
 	</div>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -9,57 +9,113 @@
 </svelte:head>
 
 <main class="z-10 px-3 text-center">
-	<article class="prose prose-neutral prose-invert pb-16 text-left">
+	<div class="pb-16 text-left">
 		<div class="mb-8 flex justify-center">
 			<img src={logo} alt="Ben Davis Logo" class="w-24" />
 		</div>
-		<h1 class="mb-0 pb-0">Ben Davis</h1>
-		<p class="mx-0 my-1">
-			<a href="https://github.com/bmdavis419" target="_blank">developer</a>,
-			<a href="https://www.youtube.com/@bmdavis419" target="_blank">youtuber</a>, and
-			<a href="https://www.youtube.com/@t3dotgg/videos" target="_blank">theo's manager</a>. based in
-			sf.
+		<h1 class="mb-0 pb-0 text-4xl font-bold tracking-tight text-neutral-100">Ben Davis</h1>
+		<p class="mx-0 mt-2 mb-8 text-neutral-300">
+			<a
+				href="https://github.com/bmdavis419"
+				target="_blank"
+				class="text-neutral-100 underline decoration-neutral-700 underline-offset-2 transition-colors hover:decoration-neutral-400"
+				>developer</a
+			>,
+			<a
+				href="https://www.youtube.com/@bmdavis419"
+				target="_blank"
+				class="text-neutral-100 underline decoration-neutral-700 underline-offset-2 transition-colors hover:decoration-neutral-400"
+				>youtuber</a
+			>, and
+			<a
+				href="https://www.youtube.com/@t3dotgg/videos"
+				target="_blank"
+				class="text-neutral-100 underline decoration-neutral-700 underline-offset-2 transition-colors hover:decoration-neutral-400"
+				>theo's manager</a
+			>. based in sf.
 		</p>
 
-		<h3>You might be looking for:</h3>
+		<h3 class="mb-4 text-lg font-medium text-neutral-200">You might be looking for:</h3>
 
-		<p>
-			<a href="/macos">My MacOS Setup</a> a collection of resources on how I setup my mac to be a power
-			user's dream. Includes karabiner config, keyboard shortcuts, tools I used to make my configs, all
-			the programs I use, and more.
-		</p>
+		<div class="space-y-3">
+			<a
+				href="/macos"
+				class="block rounded-lg border border-neutral-800 p-4 transition-all hover:border-neutral-700 hover:bg-neutral-900/50"
+			>
+				<span class="font-medium text-neutral-100">My MacOS Setup</span>
+				<span class="mt-1 block text-sm text-neutral-400"
+					>A collection of resources on how I setup my mac to be a power user's dream. Includes
+					karabiner config, keyboard shortcuts, tools I used to make my configs, all the programs I
+					use, and more.</span
+				>
+			</a>
 
-		<p>
-			<a href="/karabiner">Karabiner Config</a> my complete karabiner elements config and a visualizer
-			for all my keybindings.
-		</p>
+			<a
+				href="/karabiner"
+				class="block rounded-lg border border-neutral-800 p-4 transition-all hover:border-neutral-700 hover:bg-neutral-900/50"
+			>
+				<span class="font-medium text-neutral-100">Karabiner Config</span>
+				<span class="mt-1 block text-sm text-neutral-400"
+					>My complete karabiner elements config and a visualizer for all my keybindings.</span
+				>
+			</a>
 
-		<p>
-			<a href="/sv">SvelteKit Setup</a> a bunch of prompts/cursor rules to get your SvelteKit project
-			started.
-		</p>
+			<a
+				href="/sv"
+				class="block rounded-lg border border-neutral-800 p-4 transition-all hover:border-neutral-700 hover:bg-neutral-900/50"
+			>
+				<span class="font-medium text-neutral-100">SvelteKit Setup</span>
+				<span class="mt-1 block text-sm text-neutral-400"
+					>A bunch of prompts/cursor rules to get your SvelteKit project started.</span
+				>
+			</a>
 
-		<p>
-			<a href="https://btca.dev" target="_blank">btca (The Better Context App)</a> the best way to get
-			up to date context on the tech you're building with.
-		</p>
+			<a
+				href="https://btca.dev"
+				target="_blank"
+				class="block rounded-lg border border-neutral-800 p-4 transition-all hover:border-neutral-700 hover:bg-neutral-900/50"
+			>
+				<span class="font-medium text-neutral-100">btca (The Better Context App)</span>
+				<span class="mt-1 block text-sm text-neutral-400"
+					>The best way to get up to date context on the tech you're building with.</span
+				>
+			</a>
 
-		<p>
-			<a href="https://github.com/bmdavis419/river" target="_blank">River</a> a trpc like experience
-			for durable streams and ai agents.
-		</p>
+			<a
+				href="https://github.com/bmdavis419/river"
+				target="_blank"
+				class="block rounded-lg border border-neutral-800 p-4 transition-all hover:border-neutral-700 hover:bg-neutral-900/50"
+			>
+				<span class="font-medium text-neutral-100">River</span>
+				<span class="mt-1 block text-sm text-neutral-400"
+					>A trpc like experience for durable streams and ai agents.</span
+				>
+			</a>
 
-		<p>
-			<a href="https://insiderviz.com" target="_blank">Insiderviz</a> an insider trading data visualization
-			platform. I built this in college with the boys. Was a really cool project that is now pretty much
-			abandoned.
-		</p>
+			<a
+				href="https://insiderviz.com"
+				target="_blank"
+				class="block rounded-lg border border-neutral-800 p-4 transition-all hover:border-neutral-700 hover:bg-neutral-900/50"
+			>
+				<span class="font-medium text-neutral-100">Insiderviz</span>
+				<span class="mt-1 block text-sm text-neutral-400"
+					>An insider trading data visualization platform. I built this in college with the boys.
+					Was a really cool project that is now pretty much abandoned.</span
+				>
+			</a>
 
-		<p>
-			<a href="https://svg.davis7.sh" target="_blank">Quick SVG Background</a> A really simple webapp
-			for uploading an SVG and adding a background to it. I know it sounds dumb, but I use it all the
-			time for making thumbnails.
-		</p>
-	</article>
+			<a
+				href="https://svg.davis7.sh"
+				target="_blank"
+				class="block rounded-lg border border-neutral-800 p-4 transition-all hover:border-neutral-700 hover:bg-neutral-900/50"
+			>
+				<span class="font-medium text-neutral-100">Quick SVG Background</span>
+				<span class="mt-1 block text-sm text-neutral-400"
+					>A really simple webapp for uploading an SVG and adding a background to it. I know it
+					sounds dumb, but I use it all the time for making thumbnails.</span
+				>
+			</a>
+		</div>
+	</div>
 	<SocialLinks />
 </main>

--- a/src/routes/karabiner/+page.svelte
+++ b/src/routes/karabiner/+page.svelte
@@ -4,8 +4,11 @@
 	import Keyboard from '$lib/components/Keyboard.svelte';
 	import myConfig from './karabiner.json';
 
+	import { Check } from 'lucide-svelte';
+
 	let html = $state('');
 	let showModal = $state(false);
+	let copied = $state(false);
 
 	$effect(() => {
 		const run = async () => {
@@ -24,6 +27,10 @@
 
 	const copy = () => {
 		navigator.clipboard.writeText(JSON.stringify(myConfig));
+		copied = true;
+		setTimeout(() => {
+			copied = false;
+		}, 2000);
 	};
 </script>
 
@@ -32,21 +39,25 @@
 </svelte:head>
 
 <div class="flex flex-col items-start gap-8">
-	<a href="/" class="text-accent hover:text-accent/80 mb-2 transition-colors">← Back to Home</a>
-	<h2 class="text-primary text-2xl font-semibold">My Karabiner Config</h2>
+	<a
+		href="/"
+		class="mb-2 text-sm font-medium text-neutral-400 transition-colors hover:text-neutral-300"
+		>← Back to Home</a
+	>
+	<h2 class="text-2xl font-semibold text-neutral-100">My Karabiner Config</h2>
 
-	<p class="text-secondary leading-relaxed">
+	<p class="leading-relaxed text-neutral-300">
 		This is my "hyper key" config, you can download Karabiner elements
 		<a
 			href="https://karabiner-elements.pqrs.org/"
 			target="_blank"
 			rel="noopener noreferrer"
-			class="text-accent underline transition-opacity hover:opacity-80">here</a
+			class="text-neutral-100 underline transition-colors hover:text-white">here</a
 		>.
 	</p>
 
 	<button
-		class="bg-accent text-background mt-4 rounded-md px-4 py-2 font-semibold transition-opacity hover:opacity-80"
+		class="rounded-lg border-2 border-blue-500 bg-transparent px-4 py-2 font-medium text-blue-300 transition-all hover:border-blue-400 hover:text-blue-200"
 		onclick={() => (showModal = true)}
 	>
 		View Full Config
@@ -54,23 +65,35 @@
 
 	<Keyboard />
 
-	<p class="text-secondary">Keybindings:</p>
+	<p class="text-neutral-300">Keybindings:</p>
 	<ul class="w-full space-y-2 font-bold">
-		<li class="text-secondary border-border border-b py-2 last:border-b-0">Caps Lock to Hyper</li>
-		<li class="text-secondary border-border border-b py-2 last:border-b-0">
+		<li class="border-b border-neutral-800 py-2 text-neutral-300 last:border-b-0">
+			Caps Lock to Hyper
+		</li>
+		<li class="border-b border-neutral-800 py-2 text-neutral-300 last:border-b-0">
 			Hyper + tab to control + tab
 		</li>
-		<li class="text-secondary border-border border-b py-2 last:border-b-0">Hyper + a to cmd + a</li>
-		<li class="text-secondary border-border border-b py-2 last:border-b-0">
+		<li class="border-b border-neutral-800 py-2 text-neutral-300 last:border-b-0">
+			Hyper + a to cmd + a
+		</li>
+		<li class="border-b border-neutral-800 py-2 text-neutral-300 last:border-b-0">
 			Hyper + j/k to pageup/pagedown
 		</li>
-		<li class="text-secondary border-border border-b py-2 last:border-b-0">
+		<li class="border-b border-neutral-800 py-2 text-neutral-300 last:border-b-0">
 			Hyper + h/l to left/right arrow
 		</li>
-		<li class="text-secondary border-border border-b py-2 last:border-b-0">Hyper + c to cmd + c</li>
-		<li class="text-secondary border-border border-b py-2 last:border-b-0">Hyper + v to cmd + v</li>
-		<li class="text-secondary border-border border-b py-2 last:border-b-0">Hyper + t to cmd + t</li>
-		<li class="text-secondary border-border border-b py-2 last:border-b-0">Hyper + w to cmd + w</li>
+		<li class="border-b border-neutral-800 py-2 text-neutral-300 last:border-b-0">
+			Hyper + c to cmd + c
+		</li>
+		<li class="border-b border-neutral-800 py-2 text-neutral-300 last:border-b-0">
+			Hyper + v to cmd + v
+		</li>
+		<li class="border-b border-neutral-800 py-2 text-neutral-300 last:border-b-0">
+			Hyper + t to cmd + t
+		</li>
+		<li class="border-b border-neutral-800 py-2 text-neutral-300 last:border-b-0">
+			Hyper + w to cmd + w
+		</li>
 	</ul>
 </div>
 
@@ -85,9 +108,9 @@
 			class="z-50 max-h-[90vh] max-w-4xl overflow-auto rounded-lg border border-neutral-800 bg-neutral-900 p-6"
 		>
 			<div class="mb-4 flex items-center justify-between">
-				<h3 class="text-primary text-xl font-semibold">Full Karabiner Configuration</h3>
+				<h3 class="text-xl font-semibold text-neutral-100">Full Karabiner Configuration</h3>
 				<button
-					class="text-secondary hover:text-primary transition-colors"
+					class="text-neutral-400 transition-colors hover:text-neutral-100"
 					onclick={() => (showModal = false)}
 				>
 					✕
@@ -95,11 +118,16 @@
 			</div>
 			<div class="mb-4">
 				<button
-					class="bg-accent text-background flex items-center gap-2 rounded-md px-3 py-2 font-semibold transition-opacity hover:opacity-80"
+					class="flex items-center gap-2 rounded-lg border-2 border-blue-500 bg-transparent px-3 py-2 font-medium text-blue-300 transition-all hover:border-blue-400 hover:text-blue-200"
 					onclick={copy}
 				>
-					<Copy size={16} />
-					Copy Config
+					{#if copied}
+						<Check size={16} class="text-green-400" />
+						Copied!
+					{:else}
+						<Copy size={16} />
+						Copy Config
+					{/if}
 				</button>
 			</div>
 			<div class="rounded-lg bg-neutral-800 p-4 text-sm">

--- a/src/routes/macos/+page.svelte
+++ b/src/routes/macos/+page.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { Copy } from 'lucide-svelte';
+	import { Copy, Check } from 'lucide-svelte';
 	import SocialLinks from '$lib/components/SocialLinks.svelte';
 
 	const ghosttyContent = `---
@@ -23,9 +23,15 @@ agent: build
 
 My tmux config is located at: ~/.tmux.conf Your job is to make the changes I describe to that config file. Every time you make a change, make sure to end by giving me the command I need to restart my current tmux instance and use the changes immediately`;
 
-	const copyToClipboard = async (content: string) => {
+	let copiedId = $state<string | null>(null);
+
+	const copyToClipboard = async (content: string, id: string) => {
 		try {
 			await navigator.clipboard.writeText(content);
+			copiedId = id;
+			setTimeout(() => {
+				copiedId = null;
+			}, 2000);
 		} catch (err) {
 			console.error('Failed to copy text: ', err);
 		}
@@ -42,7 +48,9 @@ My tmux config is located at: ~/.tmux.conf Your job is to make the changes I des
 
 <main class="z-10 px-3 text-center">
 	<article class="prose prose-neutral prose-invert pb-16 text-left">
-		<a href="/" class="text-accent hover:text-accent/80 mb-8 inline-block transition-colors"
+		<a
+			href="/"
+			class="mb-8 inline-block text-sm font-medium text-neutral-400 transition-colors hover:text-neutral-300"
 			>← Back to Home</a
 		>
 
@@ -107,11 +115,16 @@ My tmux config is located at: ~/.tmux.conf Your job is to make the changes I des
 
 		<div class="relative">
 			<button
-				class="bg-accent text-background absolute right-2 top-2 flex items-center gap-1 rounded px-2 py-1 text-xs font-semibold transition-opacity hover:opacity-80"
-				onclick={() => copyToClipboard(ghosttyContent)}
+				class="absolute top-2 right-2 flex items-center gap-1 rounded border border-neutral-600 bg-neutral-800 px-2 py-1 text-xs font-medium text-neutral-300 transition-colors hover:border-neutral-500 hover:text-neutral-200"
+				onclick={() => copyToClipboard(ghosttyContent, 'ghostty')}
 			>
-				<Copy size={12} />
-				Copy
+				{#if copiedId === 'ghostty'}
+					<Check size={12} class="text-green-400" />
+					Copied!
+				{:else}
+					<Copy size={12} />
+					Copy
+				{/if}
 			</button>
 			<pre><code
 					>---
@@ -128,11 +141,16 @@ Run "ghostty +show-config --default --docs" to see the full guide on how to conf
 
 		<div class="relative">
 			<button
-				class="bg-accent text-background absolute right-2 top-2 flex items-center gap-1 rounded px-2 py-1 text-xs font-semibold transition-opacity hover:opacity-80"
-				onclick={() => copyToClipboard(cursorContent)}
+				class="absolute top-2 right-2 flex items-center gap-1 rounded border border-neutral-600 bg-neutral-800 px-2 py-1 text-xs font-medium text-neutral-300 transition-colors hover:border-neutral-500 hover:text-neutral-200"
+				onclick={() => copyToClipboard(cursorContent, 'cursor')}
 			>
-				<Copy size={12} />
-				Copy
+				{#if copiedId === 'cursor'}
+					<Check size={12} class="text-green-400" />
+					Copied!
+				{:else}
+					<Copy size={12} />
+					Copy
+				{/if}
 			</button>
 			<pre><code
 					>---
@@ -149,11 +167,16 @@ My cursor (vscode) keybindings are located at: "~/Library/Application Support/Cu
 
 		<div class="relative">
 			<button
-				class="bg-accent text-background absolute right-2 top-2 flex items-center gap-1 rounded px-2 py-1 text-xs font-semibold transition-opacity hover:opacity-80"
-				onclick={() => copyToClipboard(tmuxContent)}
+				class="absolute top-2 right-2 flex items-center gap-1 rounded border border-neutral-600 bg-neutral-800 px-2 py-1 text-xs font-medium text-neutral-300 transition-colors hover:border-neutral-500 hover:text-neutral-200"
+				onclick={() => copyToClipboard(tmuxContent, 'tmux')}
 			>
-				<Copy size={12} />
-				Copy
+				{#if copiedId === 'tmux'}
+					<Check size={12} class="text-green-400" />
+					Copied!
+				{:else}
+					<Copy size={12} />
+					Copy
+				{/if}
 			</button>
 			<pre><code
 					>---

--- a/src/routes/sv/+page.svelte
+++ b/src/routes/sv/+page.svelte
@@ -17,6 +17,7 @@
 	let toastMessage = $state<string | null>(null);
 	let toastType = $state<'success' | 'error'>('success');
 	let isLoading = $state(false);
+	let copySuccess = $state(false);
 
 	function showToast(message: string, type: 'success' | 'error' = 'success') {
 		toastMessage = message;
@@ -42,6 +43,10 @@
 			});
 
 			await navigator.clipboard.writeText(prompts);
+			copySuccess = true;
+			setTimeout(() => {
+				copySuccess = false;
+			}, 2000);
 			showToast('Prompts copied to clipboard!', 'success');
 		} catch (error) {
 			showToast(
@@ -121,86 +126,117 @@
 	<div class="space-y-8">
 		<!-- Basic Prompts -->
 		<div class="space-y-4">
-			<h2 class="text-sm font-semibold uppercase tracking-wide text-neutral-400">Setup Options</h2>
-			<div class="space-y-4">
-				<label class="flex cursor-pointer items-center gap-3">
+			<h2 class="text-sm font-semibold tracking-wide text-neutral-400 uppercase">Setup Options</h2>
+			<div class="space-y-1">
+				<label
+					class="flex cursor-pointer items-start gap-3 rounded-lg p-3 transition-colors hover:bg-neutral-900/50"
+				>
 					<input
 						type="checkbox"
 						checked={vercelSetup}
 						onchange={(e) => handleVercelChange(e.currentTarget.checked)}
-						class="h-5 w-5 cursor-pointer rounded border-neutral-600 text-blue-500"
+						class="mt-0.5 h-5 w-5 shrink-0 cursor-pointer rounded border-neutral-600 text-blue-500"
 					/>
-					<span class="text-sm font-medium text-neutral-200">Vercel Setup</span>
+					<div>
+						<span class="text-sm font-medium text-neutral-200">Vercel Setup</span>
+						<p class="mt-0.5 text-xs text-neutral-400">
+							Adds the vercel adapter and removes the default one
+						</p>
+					</div>
 				</label>
-				<p class="ml-8 text-xs text-neutral-400">
-					Adds the vercel adapter and removes the default one
-				</p>
-				<label class="flex cursor-pointer items-center gap-3">
+				<label
+					class="flex cursor-pointer items-start gap-3 rounded-lg p-3 transition-colors hover:bg-neutral-900/50"
+				>
 					<input
 						type="checkbox"
 						checked={cloudflareSetup}
 						onchange={(e) => handleCloudflareChange(e.currentTarget.checked)}
-						class="h-5 w-5 cursor-pointer rounded border-neutral-600 text-blue-500"
+						class="mt-0.5 h-5 w-5 shrink-0 cursor-pointer rounded border-neutral-600 text-blue-500"
 					/>
-					<span class="text-sm font-medium text-neutral-200">Cloudflare Setup</span>
+					<div>
+						<span class="text-sm font-medium text-neutral-200">Cloudflare Setup</span>
+						<p class="mt-0.5 text-xs text-neutral-400">
+							Adds the cloudflare adapter, sets up wrangler, and gives you the right commands to
+							deploy to cloudflare
+						</p>
+					</div>
 				</label>
-				<p class="ml-8 text-xs text-neutral-400">
-					Adds the cloudflare adapter, sets up wrangler, and gives you the right commands to deploy
-					to cloudflare
-				</p>
-				<label class="flex cursor-pointer items-center gap-3">
+				<label
+					class="flex cursor-pointer items-start gap-3 rounded-lg p-3 transition-colors hover:bg-neutral-900/50"
+				>
 					<input
 						type="checkbox"
 						bind:checked={convexSetup}
-						class="h-5 w-5 cursor-pointer rounded border-neutral-600 text-blue-500"
+						class="mt-0.5 h-5 w-5 shrink-0 cursor-pointer rounded border-neutral-600 text-blue-500"
 					/>
-					<span class="text-sm font-medium text-neutral-200">Convex Setup</span>
+					<div>
+						<span class="text-sm font-medium text-neutral-200">Convex Setup</span>
+						<p class="mt-0.5 text-xs text-neutral-400">
+							Sets up convex in your sveltekit app and gives you a good cursor rule for it
+						</p>
+					</div>
 				</label>
-				<p class="ml-8 text-xs text-neutral-400">
-					Sets up convex in your sveltekit app and gives you a good cursor rule for it
-				</p>
-				<label class="flex cursor-pointer items-center gap-3">
+				<label
+					class="flex cursor-pointer items-start gap-3 rounded-lg p-3 transition-colors hover:bg-neutral-900/50"
+				>
 					<input
 						type="checkbox"
 						bind:checked={cursorRules}
-						class="h-5 w-5 cursor-pointer rounded border-neutral-600 text-blue-500"
+						class="mt-0.5 h-5 w-5 shrink-0 cursor-pointer rounded border-neutral-600 text-blue-500"
 					/>
-					<span class="text-sm font-medium text-neutral-200">Cursor Rules</span>
+					<div>
+						<span class="text-sm font-medium text-neutral-200">Cursor Rules</span>
+						<p class="mt-0.5 text-xs text-neutral-400">
+							Adds 5 useful cursor rules for sveltekit: global, neverthrow, svelte, tailwindcss, and
+							convex
+						</p>
+					</div>
 				</label>
-				<p class="ml-8 text-xs text-neutral-400">
-					Adds 5 useful cursor rules for sveltekit: global, neverthrow, svelte, tailwindcss, and convex
-				</p>
-				<label class="flex cursor-pointer items-center gap-3">
+				<label
+					class="flex cursor-pointer items-start gap-3 rounded-lg p-3 transition-colors hover:bg-neutral-900/50"
+				>
 					<input
 						type="checkbox"
 						bind:checked={usefulPackages}
-						class="h-5 w-5 cursor-pointer rounded border-neutral-600 text-blue-500"
+						class="mt-0.5 h-5 w-5 shrink-0 cursor-pointer rounded border-neutral-600 text-blue-500"
 					/>
-					<span class="text-sm font-medium text-neutral-200">Useful Packages</span>
+					<div>
+						<span class="text-sm font-medium text-neutral-200">Useful Packages</span>
+						<p class="mt-0.5 text-xs text-neutral-400">
+							Adds useful packages for sveltekit: runed, neverthrow, and zod
+						</p>
+					</div>
 				</label>
-				<p class="ml-8 text-xs text-neutral-400">
-					Adds useful packages for sveltekit: runed, neverthrow, and zod
-				</p>
-				<label class="flex cursor-pointer items-center gap-3">
+				<label
+					class="flex cursor-pointer items-start gap-3 rounded-lg p-3 transition-colors hover:bg-neutral-900/50"
+				>
 					<input
 						type="checkbox"
 						bind:checked={asyncSvelte}
-						class="h-5 w-5 cursor-pointer rounded border-neutral-600 text-blue-500"
+						class="mt-0.5 h-5 w-5 shrink-0 cursor-pointer rounded border-neutral-600 text-blue-500"
 					/>
-					<span class="text-sm font-medium text-neutral-200">Async Svelte</span>
+					<div>
+						<span class="text-sm font-medium text-neutral-200">Async Svelte</span>
+						<p class="mt-0.5 text-xs text-neutral-400">
+							Updates the svelte.config.js file to support async svelte
+						</p>
+					</div>
 				</label>
-				<p class="ml-8 text-xs text-neutral-400">
-					Updates the svelte.config.js file to support async svelte
-				</p>
-				<label class="flex cursor-pointer items-center gap-3">
+				<label
+					class="flex cursor-pointer items-start gap-3 rounded-lg p-3 transition-colors hover:bg-neutral-900/50"
+				>
 					<input
 						type="checkbox"
 						bind:checked={helloWorld}
-						class="h-5 w-5 cursor-pointer rounded border-neutral-600 text-blue-500"
+						class="mt-0.5 h-5 w-5 shrink-0 cursor-pointer rounded border-neutral-600 text-blue-500"
 					/>
-					<span class="text-sm font-medium text-neutral-200">Hello World</span>
+					<div>
+						<span class="text-sm font-medium text-neutral-200">Hello World</span>
+						<p class="mt-0.5 text-xs text-neutral-400">
+							Makes the default page a nicer hello world
+						</p>
+					</div>
 				</label>
-				<p class="ml-8 text-xs text-neutral-400">Makes the default page a nicer hello world</p>
 			</div>
 		</div>
 
@@ -219,7 +255,7 @@
 					<div>
 						<label
 							for="topBarColor"
-							class="mb-3 block text-xs font-medium uppercase tracking-wide text-neutral-400"
+							class="mb-3 block text-xs font-medium tracking-wide text-neutral-400 uppercase"
 							>Top Bar Color</label
 						>
 						<div class="flex items-center gap-3">
@@ -239,7 +275,7 @@
 					<div>
 						<label
 							for="topBarTextColor"
-							class="mb-3 block text-xs font-medium uppercase tracking-wide text-neutral-400"
+							class="mb-3 block text-xs font-medium tracking-wide text-neutral-400 uppercase"
 							>Top Bar Text Color</label
 						>
 						<div class="flex items-center gap-3">
@@ -275,7 +311,7 @@
 					<div>
 						<label
 							for="primaryColor"
-							class="mb-3 block text-xs font-medium uppercase tracking-wide text-neutral-400"
+							class="mb-3 block text-xs font-medium tracking-wide text-neutral-400 uppercase"
 							>Primary Color</label
 						>
 						<div class="flex items-center gap-3">
@@ -301,9 +337,33 @@
 			<button
 				onclick={copyPrompts}
 				disabled={isLoading}
-				class="rounded-lg border-2 border-blue-500 bg-transparent px-4 py-2 font-medium text-blue-300 transition-all hover:border-blue-400 hover:text-blue-200 disabled:border-neutral-600 disabled:text-neutral-500"
+				class="flex items-center gap-2 rounded-lg border-2 border-blue-500 bg-transparent px-4 py-2 font-medium text-blue-300 transition-all hover:border-blue-400 hover:text-blue-200 disabled:border-neutral-600 disabled:text-neutral-500"
 			>
-				{'Copy Prompts'}
+				{#if isLoading}
+					<svg class="h-4 w-4 animate-spin" viewBox="0 0 24 24" fill="none">
+						<circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"
+						></circle>
+						<path
+							class="opacity-75"
+							fill="currentColor"
+							d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"
+						></path>
+					</svg>
+					Copying...
+				{:else if copySuccess}
+					<svg
+						class="h-4 w-4 text-green-400"
+						viewBox="0 0 24 24"
+						fill="none"
+						stroke="currentColor"
+						stroke-width="2"
+					>
+						<polyline points="20 6 9 17 4 12"></polyline>
+					</svg>
+					Copied!
+				{:else}
+					Copy Prompts
+				{/if}
 			</button>
 		</div>
 	</div>
@@ -312,10 +372,11 @@
 <!-- Toast Notification -->
 {#if toastMessage}
 	<div
-		class={`fixed bottom-8 right-8 z-50 flex items-center gap-3 rounded-xl border px-4 py-3 text-sm font-medium shadow-xl backdrop-blur-sm transition-all ${toastType === 'success' ? 'border-green-500/30 bg-green-500/10 text-green-300' : 'border-red-500/30 bg-red-500/10 text-red-300'}`}
+		class={`fixed right-8 bottom-8 z-50 flex items-center gap-3 rounded-xl border px-4 py-3 text-sm font-medium shadow-xl backdrop-blur-sm transition-all ${toastType === 'success' ? 'border-green-500/30 bg-green-500/10 text-green-300' : 'border-red-500/30 bg-red-500/10 text-red-300'}`}
 	>
-		<div class={`h-2 w-2 rounded-full ${toastType === 'success' ? 'bg-green-400' : 'bg-red-400'}`}></div>
+		<div
+			class={`h-2 w-2 rounded-full ${toastType === 'success' ? 'bg-green-400' : 'bg-red-400'}`}
+		></div>
 		{toastMessage}
 	</div>
 {/if}
-


### PR DESCRIPTION
Improve site aesthetics and user experience by fixing undefined CSS classes, enhancing interactive elements, and adding subtle animations.

This PR addresses several visual and functional improvements across the site:
- Replaced undefined Tailwind utility classes (`text-accent`, `bg-accent`, etc.) with the correct neutral palette on the Karabiner and macOS pages.
- Transformed the home page project list into visually distinct cards with hover effects.
- Implemented "Copied!" feedback for all copy buttons on macOS, Karabiner, and SvelteKit pages.
- Enhanced the SvelteKit page by grouping checkbox labels with descriptions into single clickable areas and adding loading/success states to the "Copy Prompts" button.
- Introduced a subtle fade-in-up animation for page content.
- Standardized the styling for "Back to Home" links across all subpages.

---
<p><a href="https://cursor.com/agents/bc-a12204f9-62cf-4be1-9813-9e6037124025"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a12204f9-62cf-4be1-9813-9e6037124025"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR improves site aesthetics by fixing undefined Tailwind CSS classes and adding visual enhancements. The changes successfully replace undefined utility classes (`text-accent`, `bg-accent`, etc.) with concrete neutral palette colors, transform project lists into interactive cards, and add "Copied!" feedback across multiple pages.

**Key improvements:**
- Replaced undefined CSS classes with actual Tailwind neutral colors
- Added fade-in-up animation for page content
- Converted home page project list to card-based layout with hover effects
- Implemented copy feedback on macOS, Karabiner, and SvelteKit pages
- Enhanced checkbox UI by grouping labels with descriptions
- Standardized "Back to Home" link styling

**Critical issue found:**
- `src/routes/karabiner/+page.svelte`: Removed `stopPropagation` from modal content div, causing the modal to close when clicking inside it - this breaks existing functionality

<h3>Confidence Score: 2/5</h3>

- Not safe to merge - contains a critical bug that breaks modal functionality
- While most changes are solid visual improvements, removing stopPropagation from the modal in `src/routes/karabiner/+page.svelte` breaks its core functionality by making it close whenever you click inside the modal content
- Fix `src/routes/karabiner/+page.svelte` - restore the stopPropagation handler to prevent modal from closing when clicking inside

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/routes/+page.svelte | Converted prose-styled list to custom card-based layout with hover effects - no issues |
| src/routes/karabiner/+page.svelte | Fixed undefined CSS classes and added copy feedback, but removed stopPropagation causing modal to close when clicked inside |
| src/routes/macos/+page.svelte | Fixed undefined CSS classes and added copy feedback to all copy buttons - no issues |
| src/routes/sv/+page.svelte | Enhanced checkbox layout, grouped labels with descriptions, added loading and success states to copy button - no issues |

</details>



<sub>Last reviewed commit: 69422c8</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->