### PR TITLE
Sponsors page railway styling

### DIFF
--- a/src/routes/sponsors/+page.svelte
+++ b/src/routes/sponsors/+page.svelte
@@ -42,7 +42,7 @@
 			logoClass: 'max-h-10 max-w-[9.5rem]',
 			logoContainerClass: 'border-cyan-300/10 bg-[#120f18]',
 			cardClass:
-				'border-fuchsia-400/20 bg-linear-to-br from-[#07040f] via-[#17111f] to-[#0b0812] text-neutral-100 hover:border-cyan-300/35 hover:bg-linear-to-br hover:from-[#0a0714] hover:via-[#1d1526] hover:to-[#0d0a15]',
+				'border-fuchsia-400/20 bg-linear-to-br from-[#07040f] via-[#17111f] to-[#0b0812] text-neutral-100 hover:border-fuchsia-400/55 hover:bg-linear-to-br hover:from-[#0a0714] hover:via-[#1d1526] hover:to-[#0d0a15]',
 			descriptionClass: 'text-neutral-300',
 			ctaClass: 'text-[#853CCE] group-hover:text-cyan-200'
 		},
@@ -90,10 +90,10 @@
 					href={sponsor.href}
 					target="_blank"
 					rel="noreferrer"
-					class={`group flex h-75 w-full flex-col rounded-2xl border p-5 transition-all duration-200 hover:-translate-y-0.5 ${sponsor.cardClass}`}
+					class={`group flex h-75 w-full flex-col border p-5 transition-all duration-200 hover:-translate-y-0.5 ${sponsor.cardClass}`}
 				>
 					<div
-						class={`mb-5 flex h-24 w-full shrink-0 items-center justify-center overflow-hidden rounded-xl border px-5 ${sponsor.logoContainerClass}`}
+						class={`mb-5 flex h-24 w-full shrink-0 items-center justify-center overflow-hidden border px-5 ${sponsor.logoContainerClass}`}
 					>
 						<img
 							src={sponsor.logo}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Remove corner rounding from sponsor elements and update Railway's hover border color.

<div><a href="https://cursor.com/agents/bc-5bea7d24-e673-4f81-8f5b-8fc8b69a97c7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5bea7d24-e673-4f81-8f5b-8fc8b69a97c7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- CURSOR_AGENT_PR_BODY_END -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR makes two focused visual tweaks to the sponsors page: it removes border-radius rounding from all sponsor card elements (both the outer card and the inner logo container), and updates Railway's hover border color from `hover:border-cyan-300/35` to `hover:border-fuchsia-400/55` so it aligns with Railway's existing fuchsia brand color rather than cyan.

- Removed `rounded-2xl` from sponsor card `<a>` elements and `rounded-xl` from logo container `<div>` elements across all four sponsors
- Updated Railway's hover border from `cyan-300/35` to `fuchsia-400/55`
- No logic, data, or functional changes — purely cosmetic styling
- No plan `.md` files found in the repository

<h3>Confidence Score: 5/5</h3>

- Safe to merge — changes are limited to Tailwind CSS class adjustments with no functional impact.
- Only two types of changes: removal of border-radius utility classes and a hover border color swap. No logic, routing, or data-fetching is touched. No breaking changes to existing features.
- No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/routes/sponsors/+page.svelte | Removes `rounded-2xl` from sponsor cards and `rounded-xl` from logo containers (all sponsors), and updates Railway's hover border color from `cyan-300/35` to `fuchsia-400/55`. Pure visual changes with no functional impact. |

</details>

<sub>Last reviewed commit: f3a7998</sub>

<!-- /greptile_comment -->