### PR TITLE
Add solid backgrounds to homepage cards

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -51,7 +51,7 @@
 		<div class="space-y-3">
 			<a
 				href="/sponsors"
-				class="block rounded-lg border border-neutral-800 p-4 transition-all hover:border-neutral-700 hover:bg-neutral-900/50"
+				class="block rounded-lg border border-neutral-800 bg-neutral-900 p-4 transition-all hover:border-neutral-700 hover:bg-neutral-800/80"
 			>
 				<span class="font-medium text-neutral-100">Sponsors</span>
 				<span class="mt-1 block text-sm text-neutral-400"
@@ -61,7 +61,7 @@
 
 			<a
 				href="/macos"
-				class="block rounded-lg border border-neutral-800 p-4 transition-all hover:border-neutral-700 hover:bg-neutral-900/50"
+				class="block rounded-lg border border-neutral-800 bg-neutral-900 p-4 transition-all hover:border-neutral-700 hover:bg-neutral-800/80"
 			>
 				<span class="font-medium text-neutral-100">My MacOS Setup</span>
 				<span class="mt-1 block text-sm text-neutral-400"
@@ -73,7 +73,7 @@
 
 			<a
 				href="/karabiner"
-				class="block rounded-lg border border-neutral-800 p-4 transition-all hover:border-neutral-700 hover:bg-neutral-900/50"
+				class="block rounded-lg border border-neutral-800 bg-neutral-900 p-4 transition-all hover:border-neutral-700 hover:bg-neutral-800/80"
 			>
 				<span class="font-medium text-neutral-100">Karabiner Config</span>
 				<span class="mt-1 block text-sm text-neutral-400"
@@ -83,7 +83,7 @@
 
 			<a
 				href="/sv"
-				class="block rounded-lg border border-neutral-800 p-4 transition-all hover:border-neutral-700 hover:bg-neutral-900/50"
+				class="block rounded-lg border border-neutral-800 bg-neutral-900 p-4 transition-all hover:border-neutral-700 hover:bg-neutral-800/80"
 			>
 				<span class="font-medium text-neutral-100">SvelteKit Setup</span>
 				<span class="mt-1 block text-sm text-neutral-400"
@@ -94,7 +94,7 @@
 			<a
 				href="https://btca.dev"
 				target="_blank"
-				class="block rounded-lg border border-neutral-800 p-4 transition-all hover:border-neutral-700 hover:bg-neutral-900/50"
+				class="block rounded-lg border border-neutral-800 bg-neutral-900 p-4 transition-all hover:border-neutral-700 hover:bg-neutral-800/80"
 			>
 				<span class="font-medium text-neutral-100">btca (The Better Context App)</span>
 				<span class="mt-1 block text-sm text-neutral-400"
@@ -105,7 +105,7 @@
 			<a
 				href="https://github.com/bmdavis419/river"
 				target="_blank"
-				class="block rounded-lg border border-neutral-800 p-4 transition-all hover:border-neutral-700 hover:bg-neutral-900/50"
+				class="block rounded-lg border border-neutral-800 bg-neutral-900 p-4 transition-all hover:border-neutral-700 hover:bg-neutral-800/80"
 			>
 				<span class="font-medium text-neutral-100">River</span>
 				<span class="mt-1 block text-sm text-neutral-400"
@@ -116,7 +116,7 @@
 			<a
 				href="https://insiderviz.com"
 				target="_blank"
-				class="block rounded-lg border border-neutral-800 p-4 transition-all hover:border-neutral-700 hover:bg-neutral-900/50"
+				class="block rounded-lg border border-neutral-800 bg-neutral-900 p-4 transition-all hover:border-neutral-700 hover:bg-neutral-800/80"
 			>
 				<span class="font-medium text-neutral-100">Insiderviz</span>
 				<span class="mt-1 block text-sm text-neutral-400"
@@ -128,7 +128,7 @@
 			<a
 				href="https://svg.davis7.sh"
 				target="_blank"
-				class="block rounded-lg border border-neutral-800 p-4 transition-all hover:border-neutral-700 hover:bg-neutral-900/50"
+				class="block rounded-lg border border-neutral-800 bg-neutral-900 p-4 transition-all hover:border-neutral-700 hover:bg-neutral-800/80"
 			>
 				<span class="font-medium text-neutral-100">Quick SVG Background</span>
 				<span class="mt-1 block text-sm text-neutral-400"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds `bg-neutral-900` backgrounds to all homepage link cards so they no longer have transparent backgrounds that let the grid-pattern lines bleed through.

**Before:** Cards had no background color, causing the grid-pattern overlay to show through awkwardly.

**After:** Cards have solid `bg-neutral-900` backgrounds (similar to the sponsors page approach), with a slightly lighter `bg-neutral-800/80` on hover. Works correctly in both dark and light themes since the neutral color values are swapped via CSS custom properties.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7b52f069-4057-4c7e-aae7-653404c025a6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7b52f069-4057-4c7e-aae7-653404c025a6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds solid `bg-neutral-900` backgrounds to all 8 homepage link cards to prevent the grid-pattern overlay (defined in `+layout.svelte`) from bleeding through transparent card backgrounds. Also updates the hover state from `hover:bg-neutral-900/50` to `hover:bg-neutral-800/80` for a slightly lighter visual feedback. The change is purely cosmetic (Tailwind utility classes only), affects no logic or structure, and works correctly in both dark and light themes because the neutral color scale is swapped via CSS custom properties in `app.css`. No plan markdown files were found in the repository.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it's a minimal CSS-only change with no risk of breaking existing features.
- The change is limited to adding/modifying Tailwind background utility classes on 8 identical card elements. No JavaScript, no structural HTML changes, no new dependencies. Verified that the neutral color custom properties are correctly swapped for light mode in app.css, so both themes work as expected.
- No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/routes/+page.svelte | Adds `bg-neutral-900` background and updates hover to `bg-neutral-800/80` on all 8 homepage link cards. CSS-only change, no structural or logic modifications. Works correctly in both dark and light themes via CSS custom property swapping in `app.css`. |

</details>

<sub>Last reviewed commit: 54311e9</sub>

<!-- /greptile_comment -->