### PR TITLE
fix: add missing background to State of AI card

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -62,7 +62,7 @@
 			<a
 				href="https://ai.davis7.sh/"
 				target="_blank"
-				class="block rounded-lg border border-neutral-800 p-4 transition-all hover:border-neutral-700 hover:bg-neutral-900/50"
+				class="block rounded-lg border border-neutral-800 bg-neutral-900 p-4 transition-all hover:border-neutral-700 hover:bg-neutral-800/80"
 			>
 				<span class="font-medium text-neutral-100">My "State of AI"</span>
 				<span class="mt-1 block text-sm text-neutral-400"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The "My State of AI" card on the homepage was missing its `bg-neutral-900` background and had a different hover style (`hover:bg-neutral-900/50`) compared to every other card in the list.

### Changes

- Added `bg-neutral-900` to the State of AI card link
- Changed hover from `hover:bg-neutral-900/50` to `hover:bg-neutral-800/80` to match sibling cards

### Before → After (classes)

**Before:** `block rounded-lg border border-neutral-800 p-4 transition-all hover:border-neutral-700 hover:bg-neutral-900/50`

**After:** `block rounded-lg border border-neutral-800 bg-neutral-900 p-4 transition-all hover:border-neutral-700 hover:bg-neutral-800/80`

This now matches the exact styling of every other card (Sponsors, MacOS Setup, Karabiner, btca, Quick SVG Background).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bfa775b9-e654-444b-9ab9-4c045bdbc60e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bfa775b9-e654-444b-9ab9-4c045bdbc60e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix missing background on State of AI card
> Adds a default `bg-neutral-900` background to the State of AI card anchor element in [+page.svelte](https://github.com/davis7dotsh/davis7dotsh/pull/8/files#diff-1e1270da740e81dd13f8a65057582b0fce8a5fb3817ef913f3e90d7f82c4e9df). Also updates the hover state from `hover:bg-neutral-900/50` to `hover:bg-neutral-800/80`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7bf6df4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a styling inconsistency on the homepage where the \"My State of AI\" card was missing `bg-neutral-900` and used a different hover style compared to all other cards in the list.

- Added `bg-neutral-900` to the State of AI card, matching every sibling card.
- Updated hover class from `hover:bg-neutral-900/50` to `hover:bg-neutral-800/80`, bringing it in line with the rest.
- No logic changes — purely a visual fix that restores consistent styling across all homepage cards.
- No plan files were found in the repository.

<h3>Confidence Score: 5/5</h3>

Safe to merge — single-line CSS class fix with no functional impact.

The change is a minimal, isolated CSS class update that makes one card consistent with five others on the same page. No logic, data, or routing is affected.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/routes/+page.svelte | Added `bg-neutral-900` and changed hover class to `hover:bg-neutral-800/80` on the State of AI card, making it consistent with all sibling cards. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: add missing background to State of ..."](https://github.com/davis7dotsh/davis7dotsh/commit/7bf6df4943d27c5c1939a66773f580849c00307e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27002394)</sub>

<!-- /greptile_comment -->