### PR TITLE
element tracking updates

### DIFF
--- a/src/routes/font/+page.svelte
+++ b/src/routes/font/+page.svelte
@@ -1,5 +1,9 @@
 <script lang="ts">
 	import SocialLinks from '$lib/components/SocialLinks.svelte';
+
+	let height = 0;
+
+	$inspect(height);
 </script>
 
 <svelte:head>
@@ -8,7 +12,12 @@
 </svelte:head>
 
 <main class="px-3">
-	<div class="pb-16">
+	<div
+		class="pb-16"
+		@attach={(el) => {
+			height = el.clientHeight;
+		}}
+	>
 		<a
 			href="/"
 			class="mb-6 inline-flex text-sm text-neutral-400 underline decoration-neutral-800 underline-offset-4 transition-colors hover:text-neutral-200 hover:decoration-neutral-500"


### PR DESCRIPTION
## Summary
- add a height inspection value on the font page
- use the attach directive to update height from the page content

## Testing
- not run

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Changes

- Added a reactive `height` variable initialized to `0` in the font page component
- Added `$inspect(height)` to observe height value changes at runtime
- Updated the wrapping `<div>` element with an `@attach` callback to track and update the element's rendered height (`el.clientHeight`)

No auth service implementation or database schema changes are included in this PR.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Test Svelte `@attach` directive and `$inspect` in the font page component
> Adds a `height` variable to [+page.svelte](https://github.com/davis7dotsh/davis7dotsh/pull/9/files#diff-0a27a94ae05ac126d51f1121ea5e06746e010d267f425a7c778f64b8b3c1d18d) that captures the `clientHeight` of the root div via an `@attach` directive when the element mounts. Uses `$inspect(height)` to log the value at runtime, exercising these Svelte directives in a real component.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 679b759. 1 file reviewed, 1 issue evaluated, 0 issues filtered, 1 comment posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR experiments with Svelte 5's `@attach` directive to capture the page content's height. The `height` variable is set but never consumed in the template, and a `$inspect` debug call has been left in — which will emit console logs in production.

No plan `.md` files were found in the repository.

<h3>Confidence Score: 4/5</h3>

The `$inspect` debug statement should be removed before merging to production.

One P1 finding remains: `$inspect(height)` will log to the browser console in production. The rest are P2 style/completeness notes that don't block functionality.

src/routes/font/+page.svelte — remove `$inspect` before merging.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/routes/font/+page.svelte | Adds a `height` variable captured via the `@attach` directive, but the variable is never used in the template and a `$inspect` debug call is left in. |

</details>

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22davis7dotsh%2Fdavis7dotsh%22%20on%20the%20existing%20branch%20%22davis%2Fdirectives-test%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22davis%2Fdirectives-test%22.%0A%0AFix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Asrc%2Froutes%2Ffont%2F%2Bpage.svelte%3A6%0A**Debug%20%60%24inspect%60%20left%20in%20production%20code**%0A%0A%60%24inspect%60%20is%20Svelte%205's%20development-only%20debugging%20rune%20%E2%80%94%20it%20emits%20a%20%60console.log%60%20on%20every%20reactive%20update.%20Leaving%20it%20here%20means%20the%20%60height%60%20value%20will%20be%20logged%20to%20the%20console%20in%20production%20builds.%0A%0A%60%60%60suggestion%0A%09%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%203%0Asrc%2Froutes%2Ffont%2F%2Bpage.svelte%3A4-6%0A**%60height%60%20captured%20but%20never%20used**%0A%0A%60height%60%20is%20populated%20via%20%60%40attach%60%20but%20is%20never%20referenced%20in%20the%20template%20or%20passed%20anywhere%2C%20so%20it%20has%20no%20effect%20on%20the%20page.%20If%20this%20is%20only%20an%20experiment%2C%20both%20the%20variable%20and%20the%20%60%40attach%60%20directive%20can%20be%20removed.%20If%20the%20intent%20is%20to%20display%20or%20use%20the%20height%2C%20the%20template%20will%20need%20a%20binding%20to%20it.%0A%0A%23%23%23%20Issue%203%20of%203%0Asrc%2Froutes%2Ffont%2F%2Bpage.svelte%3A17-19%0A**%60%40attach%60%20captures%20height%20only%20at%20mount**%0A%0AThe%20callback%20fires%20once%20when%20the%20element%20is%20attached%20to%20the%20DOM.%20%60clientHeight%60%20at%20that%20moment%20may%20be%200%20or%20incorrect%20if%20the%20page's%20images%2Ffonts%20haven't%20finished%20loading%20yet.%20If%20an%20accurate%20or%20live%20measurement%20is%20needed%2C%20consider%20a%20%60ResizeObserver%60%20inside%20the%20attachment%20that%20returns%20a%20cleanup%20function%3A%0A%0A%60%60%60svelte%0A%40attach%3D%7B%28el%29%20%3D%3E%20%7B%0A%20%20%20%20const%20ro%20%3D%20new%20ResizeObserver%28%28%29%20%3D%3E%20%7B%0A%20%20%20%20%20%20%20%20height%20%3D%20el.clientHeight%3B%0A%20%20%20%20%7D%29%3B%0A%20%20%20%20ro.observe%28el%29%3B%0A%20%20%20%20return%20%28%29%20%3D%3E%20ro.disconnect%28%29%3B%0A%7D%7D%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: src/routes/font/+page.svelte
Line: 6

Comment:
**Debug `$inspect` left in production code**

`$inspect` is Svelte 5's development-only debugging rune — it emits a `console.log` on every reactive update. Leaving it here means the `height` value will be logged to the console in production builds.

```suggestion
	
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: src/routes/font/+page.svelte
Line: 4-6

Comment:
**`height` captured but never used**

`height` is populated via `@attach` but is never referenced in the template or passed anywhere, so it has no effect on the page. If this is only an experiment, both the variable and the `@attach` directive can be removed. If the intent is to display or use the height, the template will need a binding to it.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: src/routes/font/+page.svelte
Line: 17-19

Comment:
**`@attach` captures height only at mount**

The callback fires once when the element is attached to the DOM. `clientHeight` at that moment may be 0 or incorrect if the page's images/fonts haven't finished loading yet. If an accurate or live measurement is needed, consider a `ResizeObserver` inside the attachment that returns a cleanup function:

```svelte
@attach={(el) => {
    const ro = new ResizeObserver(() => {
        height = el.clientHeight;
    });
    ro.observe(el);
    return () => ro.disconnect();
}}
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Test Svelte directives"](https://github.com/davis7dotsh/davis7dotsh/commit/679b759dad15121152a330efb8727ae1579497b6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28571071)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->