### PR TITLE
Apply refined site design system

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -85,6 +85,7 @@ html[data-theme='light'] {
 	--color-neutral-800: #f1f2f0;
 	--color-neutral-900: #f3f3ef;
 	--color-neutral-950: #fafaf8;
+
 	color-scheme: light;
 	--color-bg: #fafaf8;
 	--color-bg-soft: #f3f3ef;
@@ -139,7 +140,7 @@ body {
 }
 
 .brand-link,
-.prose a {
+.prose a:not(.back-link) {
 	color: var(--color-link);
 	text-decoration: none;
 	border-bottom: 1px solid var(--color-border-strong);
@@ -149,13 +150,14 @@ body {
 }
 
 .brand-link:hover,
-.prose a:hover {
+.prose a:not(.back-link):hover {
 	color: var(--color-link-hover);
 	border-bottom-color: var(--color-link-hover);
 }
 
 .back-link {
 	@apply inline-flex text-sm font-medium;
+
 	color: var(--color-text-subtle);
 	transition: color 160ms ease;
 }
@@ -172,6 +174,7 @@ body {
 
 .resource-card {
 	@apply block p-4 text-left transition-all;
+
 	background: var(--color-surface);
 	border: 1px solid var(--color-border);
 	box-shadow: var(--shadow-surface);
@@ -183,8 +186,22 @@ body {
 	transform: translateY(-1px);
 }
 
+.headline-text,
+.resource-title {
+	color: var(--color-text);
+}
+
+.resource-subtitle {
+	color: var(--color-text-subtle);
+}
+
+.muted-text {
+	color: var(--color-text-muted);
+}
+
 .button {
 	@apply inline-flex items-center justify-center gap-2 px-4 py-2 text-sm font-medium transition-all disabled:cursor-not-allowed;
+
 	background: var(--color-surface);
 	border: 1px solid var(--color-border-strong);
 	color: var(--color-text);
@@ -214,6 +231,7 @@ input:focus-visible {
 
 .icon-button {
 	@apply inline-flex items-center justify-center transition-all;
+
 	background: color-mix(in srgb, var(--color-surface) 88%, transparent);
 	border: 1px solid var(--color-border);
 	color: var(--color-text-muted);
@@ -228,6 +246,7 @@ input:focus-visible {
 
 .field-input {
 	@apply px-3 py-2 font-mono text-xs;
+
 	background: var(--color-surface);
 	border: 1px solid var(--color-border);
 	color: var(--color-text);
@@ -243,6 +262,7 @@ input:focus-visible {
 
 .option-checkbox {
 	@apply mt-0.5 h-5 w-5 shrink-0 cursor-pointer;
+
 	accent-color: var(--color-accent-cyan);
 }
 
@@ -290,11 +310,13 @@ input:focus-visible {
 
 .prose :where(h1, h2, h3, h4, h5, h6) {
 	@apply font-medium tracking-tight;
+
 	color: var(--color-text);
 }
 
 .prose strong {
 	@apply font-semibold;
+
 	color: var(--color-text);
 }
 

--- a/src/app.css
+++ b/src/app.css
@@ -18,6 +18,20 @@
 	--color-neutral-800: #262626;
 	--color-neutral-900: #171717;
 	--color-neutral-950: #0a0a0a;
+
+	--color-ink: #0b0d10;
+	--color-graphite: #14171c;
+	--color-slate: #1d2127;
+	--color-panel: #232831;
+	--color-concrete: #2a2f36;
+	--color-cloud: #e5e7eb;
+	--color-paper: #f5f6f7;
+	--color-accent-cyan: #00b8d9;
+	--color-accent-cyan-soft: #a6f3ff;
+	--color-success: #22c55e;
+	--color-warning: #d97706;
+	--color-context-violet: #8b5cf6;
+	--color-danger: #dc2626;
 }
 
 @font-face {
@@ -36,32 +50,60 @@
 
 :root {
 	font-family: var(--font-family-geist);
-	background-color: var(--color-neutral-950);
-	color: var(--color-neutral-200);
+	background-color: var(--color-ink);
+	color: var(--color-cloud);
 	color-scheme: dark;
+	--color-bg: var(--color-ink);
+	--color-bg-soft: var(--color-graphite);
+	--color-surface: var(--color-slate);
+	--color-surface-elevated: var(--color-panel);
+	--color-surface-hover: var(--color-concrete);
+	--color-text: var(--color-paper);
+	--color-text-muted: #b8bec7;
+	--color-text-subtle: #838b96;
+	--color-border: rgba(229, 231, 235, 0.12);
+	--color-border-strong: rgba(229, 231, 235, 0.22);
+	--color-focus: var(--color-accent-cyan);
+	--color-link: var(--color-paper);
+	--color-link-hover: var(--color-accent-cyan);
 	--grid-color: rgba(255, 255, 255, 0.05);
-	--social-link-color: var(--color-neutral-400);
-	--social-link-hover: var(--color-neutral-100);
-	--youtube-play-color: #0a0a0a;
+	--social-link-color: var(--color-text-subtle);
+	--social-link-hover: var(--color-paper);
+	--youtube-play-color: var(--color-ink);
+	--shadow-surface: 0 1px 0 rgba(255, 255, 255, 0.03) inset;
 }
 
 html[data-theme='light'] {
-	--color-neutral-50: #0a0a0a;
-	--color-neutral-100: #171717;
-	--color-neutral-200: #262626;
-	--color-neutral-300: #404040;
-	--color-neutral-400: #525252;
-	--color-neutral-500: #737373;
-	--color-neutral-600: #a3a3a3;
-	--color-neutral-700: #d4d4d4;
-	--color-neutral-800: #e5e5e5;
-	--color-neutral-900: #f5f5f5;
-	--color-neutral-950: #fafafa;
+	--color-neutral-50: #0b0d10;
+	--color-neutral-100: #282f36;
+	--color-neutral-200: #3d454d;
+	--color-neutral-300: #5e6670;
+	--color-neutral-400: #7c838b;
+	--color-neutral-500: #929891;
+	--color-neutral-600: #d3d5d0;
+	--color-neutral-700: #e7e7e1;
+	--color-neutral-800: #f1f2f0;
+	--color-neutral-900: #f3f3ef;
+	--color-neutral-950: #fafaf8;
 	color-scheme: light;
-	--grid-color: rgba(0, 0, 0, 0.06);
-	--social-link-color: var(--color-neutral-600);
-	--social-link-hover: var(--color-neutral-100);
+	--color-bg: #fafaf8;
+	--color-bg-soft: #f3f3ef;
+	--color-surface: #ffffff;
+	--color-surface-elevated: #f1f2f0;
+	--color-surface-hover: #e7e7e1;
+	--color-text: #0b0d10;
+	--color-text-muted: #4b5560;
+	--color-text-subtle: #6f7670;
+	--color-border: rgba(11, 13, 16, 0.12);
+	--color-border-strong: rgba(11, 13, 16, 0.22);
+	--color-focus: var(--color-accent-cyan);
+	--color-link: #0b0d10;
+	--color-link-hover: #008ba3;
+	--grid-color: rgba(11, 13, 16, 0.055);
+	--social-link-color: var(--color-text-subtle);
+	--social-link-hover: var(--color-text);
 	--youtube-play-color: #ffffff;
+	--shadow-surface: 0 1px 0 rgba(255, 255, 255, 0.72) inset;
 }
 
 html,
@@ -70,20 +112,16 @@ body {
 }
 
 html {
-	background-color: var(--color-neutral-950);
+	background-color: var(--color-bg);
 }
 
 body {
 	margin: 0;
 	min-height: 100vh;
-	background-color: var(--color-neutral-950);
-	background-image: linear-gradient(
-		to bottom right,
-		var(--color-neutral-950),
-		var(--color-neutral-900)
-	);
+	background-color: var(--color-bg);
+	background-image: linear-gradient(to bottom right, var(--color-bg), var(--color-bg-soft));
 	background-attachment: fixed;
-	color: var(--color-neutral-200);
+	color: var(--color-text-muted);
 	transition:
 		background-color 0.2s ease,
 		color 0.2s ease;
@@ -100,6 +138,140 @@ body {
 	color: var(--social-link-color);
 }
 
+.brand-link,
+.prose a {
+	color: var(--color-link);
+	text-decoration: none;
+	border-bottom: 1px solid var(--color-border-strong);
+	transition:
+		border-color 160ms ease,
+		color 160ms ease;
+}
+
+.brand-link:hover,
+.prose a:hover {
+	color: var(--color-link-hover);
+	border-bottom-color: var(--color-link-hover);
+}
+
+.back-link {
+	@apply inline-flex text-sm font-medium;
+	color: var(--color-text-subtle);
+	transition: color 160ms ease;
+}
+
+.back-link:hover {
+	color: var(--color-text);
+}
+
+.surface {
+	background: var(--color-surface);
+	border: 1px solid var(--color-border);
+	box-shadow: var(--shadow-surface);
+}
+
+.resource-card {
+	@apply block p-4 text-left transition-all;
+	background: var(--color-surface);
+	border: 1px solid var(--color-border);
+	box-shadow: var(--shadow-surface);
+}
+
+.resource-card:hover {
+	background: var(--color-surface-elevated);
+	border-color: var(--color-border-strong);
+	transform: translateY(-1px);
+}
+
+.button {
+	@apply inline-flex items-center justify-center gap-2 px-4 py-2 text-sm font-medium transition-all disabled:cursor-not-allowed;
+	background: var(--color-surface);
+	border: 1px solid var(--color-border-strong);
+	color: var(--color-text);
+	box-shadow: var(--shadow-surface);
+}
+
+.button:hover:not(:disabled) {
+	background: var(--color-surface-elevated);
+	border-color: var(--color-focus);
+	color: var(--color-text);
+}
+
+.button:focus-visible,
+.icon-button:focus-visible,
+.resource-card:focus-visible,
+.brand-link:focus-visible,
+.back-link:focus-visible,
+input:focus-visible {
+	outline: 1px solid var(--color-focus);
+	outline-offset: 3px;
+}
+
+.button:disabled {
+	color: var(--color-text-subtle);
+	border-color: var(--color-border);
+}
+
+.icon-button {
+	@apply inline-flex items-center justify-center transition-all;
+	background: color-mix(in srgb, var(--color-surface) 88%, transparent);
+	border: 1px solid var(--color-border);
+	color: var(--color-text-muted);
+	box-shadow: var(--shadow-surface);
+}
+
+.icon-button:hover {
+	background: var(--color-surface-elevated);
+	border-color: var(--color-border-strong);
+	color: var(--color-text);
+}
+
+.field-input {
+	@apply px-3 py-2 font-mono text-xs;
+	background: var(--color-surface);
+	border: 1px solid var(--color-border);
+	color: var(--color-text);
+}
+
+.option-row {
+	@apply flex cursor-pointer items-start gap-3 p-3 transition-colors;
+}
+
+.option-row:hover {
+	background: color-mix(in srgb, var(--color-surface-elevated) 62%, transparent);
+}
+
+.option-checkbox {
+	@apply mt-0.5 h-5 w-5 shrink-0 cursor-pointer;
+	accent-color: var(--color-accent-cyan);
+}
+
+.code-chip {
+	background: color-mix(in srgb, var(--color-surface-elevated) 70%, transparent);
+	border: 1px solid var(--color-border);
+	color: var(--color-text);
+}
+
+.success-text {
+	color: var(--color-success);
+}
+
+.toast {
+	@apply fixed right-8 bottom-8 z-50 flex items-center gap-3 border px-4 py-3 text-sm font-medium shadow-xl backdrop-blur-sm transition-all;
+}
+
+.toast-success {
+	background: color-mix(in srgb, var(--color-success) 12%, var(--color-bg));
+	border-color: color-mix(in srgb, var(--color-success) 32%, transparent);
+	color: var(--color-success);
+}
+
+.toast-error {
+	background: color-mix(in srgb, var(--color-danger) 12%, var(--color-bg));
+	border-color: color-mix(in srgb, var(--color-danger) 32%, transparent);
+	color: var(--color-danger);
+}
+
 .grid-pattern {
 	background-image:
 		linear-gradient(to right, var(--grid-color) 1px, transparent 1px),
@@ -112,22 +284,24 @@ body {
 }
 
 .prose {
-	@apply text-neutral-300;
+	color: var(--color-text-muted);
 	max-width: 65ch;
 }
 
 .prose :where(h1, h2, h3, h4, h5, h6) {
-	@apply font-medium tracking-tight text-neutral-100;
+	@apply font-medium tracking-tight;
+	color: var(--color-text);
 }
 
 .prose strong {
-	@apply font-semibold text-neutral-100;
+	@apply font-semibold;
+	color: var(--color-text);
 }
 
 .prose :where(code):not(:where(pre code)) {
-	color: var(--color-neutral-100);
-	background-color: color-mix(in srgb, var(--color-neutral-800) 55%, transparent);
-	border: 1px solid var(--color-neutral-700);
+	color: var(--color-text);
+	background-color: color-mix(in srgb, var(--color-surface-elevated) 70%, transparent);
+	border: 1px solid var(--color-border);
 	padding: 0.125rem 0.25rem;
 	font-weight: 500;
 }
@@ -138,22 +312,12 @@ body {
 }
 
 .prose :where(pre) {
-	background-color: var(--color-neutral-900);
-	border: 1px solid var(--color-neutral-700);
+	background-color: var(--color-surface);
+	border: 1px solid var(--color-border);
 }
 
 .prose :where(pre code) {
-	color: var(--color-neutral-100);
-}
-
-.prose a {
-	@apply text-neutral-100 transition-colors hover:text-neutral-50;
-	text-decoration: none;
-	border-bottom: 1px solid var(--color-neutral-700);
-}
-
-.prose a:hover {
-	border-bottom-color: var(--color-neutral-400);
+	color: var(--color-text);
 }
 
 @keyframes fade-in-up {

--- a/src/app.html
+++ b/src/app.html
@@ -35,13 +35,13 @@
 			}
 
 			body {
-				background-color: #0a0a0a;
-				color: #e5e5e5;
+				background-color: #0b0d10;
+				color: #e5e7eb;
 			}
 
 			html[data-theme='light'] body {
-				background-color: #fafafa;
-				color: #262626;
+				background-color: #fafaf8;
+				color: #0b0d10;
 			}
 		</style>
 		%sveltekit.head%

--- a/src/lib/components/Keyboard.svelte
+++ b/src/lib/components/Keyboard.svelte
@@ -188,14 +188,13 @@
 	});
 </script>
 
-<section
-	class="flex w-full items-center gap-6 rounded-lg border border-neutral-800/70 bg-neutral-900/55 p-6 backdrop-blur-sm"
->
+<section class="surface flex w-full items-center gap-6 p-6 backdrop-blur-sm">
 	<div class="shrink-0">
 		<div
-			class="flex h-16 w-16 items-center justify-center rounded-lg bg-linear-to-br from-blue-500 to-orange-600"
+			class="flex h-16 w-16 items-center justify-center border"
+			style="background: color-mix(in srgb, var(--color-accent-cyan) 12%, var(--color-surface)); border-color: var(--color-border-strong)"
 		>
-			<svg class="h-8 w-8 text-neutral-50" fill="currentColor" viewBox="0 0 24 24">
+			<svg class="h-8 w-8" style="color: var(--color-text)" fill="currentColor" viewBox="0 0 24 24">
 				<path
 					d="M20 4H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zM9 17H7v-2h2v2zm0-4H7v-2h2v2zm0-4H7V7h2v2zm4 8h-2v-2h2v2zm0-4h-2v-2h2v2zm0-4h-2V7h2v2zm4 8h-2v-2h2v2zm0-4h-2v-2h2v2zm0-4h-2V7h2v2z"
 				/>
@@ -203,12 +202,12 @@
 		</div>
 	</div>
 	<div class="flex-1">
-		<h2 class="mb-2 text-2xl font-bold text-neutral-50">{keyTitle}</h2>
-		<p class="text-neutral-200/75">{keyDescription}</p>
+		<h2 class="mb-2 text-2xl font-bold" style="color: var(--color-text)">{keyTitle}</h2>
+		<p style="color: var(--color-text-muted)">{keyDescription}</p>
 	</div>
 </section>
 
-<div class="w-full overflow-x-auto rounded-lg p-4">
+<div class="w-full overflow-x-auto p-4">
 	<svg viewBox="0 0 {svgWidth} {svgHeight}" class="h-auto w-full">
 		{#each keys as key}
 			{@const isCapsLock = key.label === 'Caps'}
@@ -227,23 +226,28 @@
 					y={key.y}
 					width={key.width}
 					height={keyHeight}
-					rx={6}
-					class={isCapsLock
-						? 'fill-orange-500/80 stroke-orange-400 stroke-2 drop-shadow-[0_0_10px_rgba(251,146,60,0.8)] filter'
+					rx={0}
+					fill={isCapsLock
+						? 'var(--color-warning)'
 						: isHovered
-							? 'fill-blue-600/80 stroke-blue-400 stroke-2 drop-shadow-[0_0_8px_rgba(59,130,246,0.5)] filter'
+							? 'color-mix(in srgb, var(--color-accent-cyan) 42%, var(--color-surface))'
 							: hasKeybinding
-								? 'fill-blue-400/40 stroke-blue-300/50 stroke-1 drop-shadow-sm backdrop-blur-sm'
-								: 'fill-neutral-50/20 stroke-neutral-50/30 stroke-1 drop-shadow-sm backdrop-blur-sm'}
+								? 'color-mix(in srgb, var(--color-accent-cyan) 18%, var(--color-surface))'
+								: 'var(--color-surface)'}
+					stroke={isCapsLock
+						? 'color-mix(in srgb, var(--color-warning) 68%, var(--color-border))'
+						: isHovered || hasKeybinding
+							? 'color-mix(in srgb, var(--color-accent-cyan) 58%, var(--color-border))'
+							: 'var(--color-border)'}
+					stroke-width={isHovered || isCapsLock ? 2 : 1}
 				/>
 				<text
 					x={key.x + key.width / 2}
 					y={key.y + keyHeight / 2}
 					text-anchor="middle"
 					dominant-baseline="central"
-					class={isCapsLock
-						? 'fill-neutral-50 text-sm font-medium drop-shadow-sm select-none'
-						: 'fill-neutral-50 text-sm font-medium select-none'}
+					class="text-sm font-medium select-none"
+					fill={isCapsLock ? '#fff' : 'var(--color-text)'}
 				>
 					{key.label}
 				</text>

--- a/src/lib/components/ThemeToggle.svelte
+++ b/src/lib/components/ThemeToggle.svelte
@@ -58,7 +58,7 @@
 <button
 	type="button"
 	onclick={toggleTheme}
-	class="fixed top-4 right-4 z-50 flex h-11 w-11 items-center justify-center rounded-full border border-neutral-600 bg-neutral-950/80 text-neutral-200 shadow-sm backdrop-blur transition-[transform,background-color,border-color,color] duration-200 hover:scale-105 hover:border-neutral-500 hover:bg-neutral-900/90"
+	class="icon-button fixed top-4 right-4 z-50 h-11 w-11 backdrop-blur transition-[transform,background-color,border-color,color] duration-200 hover:-translate-y-px"
 	aria-label="Toggle color theme"
 	title="Toggle color theme"
 >

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -26,7 +26,7 @@
 	<meta name="color-scheme" content="dark light" />
 </svelte:head>
 
-<div class="relative min-h-screen w-full text-neutral-50">
+<div class="relative min-h-screen w-full">
 	<div
 		class="grid-pattern fixed inset-0 h-full w-full [mask-image:linear-gradient(to_bottom,white_0%,white_75%,transparent_100%)]"
 	></div>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -15,7 +15,8 @@
 				width="96"
 				height="61"
 				aria-hidden="true"
-				class="w-24 text-neutral-50"
+				class="w-24"
+				style="color: var(--color-text)"
 				xmlns="http://www.w3.org/2000/svg"
 			>
 				<path
@@ -24,103 +25,73 @@
 				/>
 			</svg>
 		</div>
-		<h1 class="mb-0 pb-0 text-4xl font-bold tracking-tight text-neutral-100">Ben Davis</h1>
-		<p class="mx-0 mt-2 mb-8 text-neutral-300">
-			<a
-				href="https://github.com/bmdavis419"
-				target="_blank"
-				class="text-neutral-100 underline decoration-neutral-700 underline-offset-2 transition-colors hover:decoration-neutral-400"
-				>developer</a
-			>,
-			<a
-				href="https://www.youtube.com/@bmdavis419"
-				target="_blank"
-				class="text-neutral-100 underline decoration-neutral-700 underline-offset-2 transition-colors hover:decoration-neutral-400"
-				>youtuber</a
-			>, and
-			<a
-				href="https://www.youtube.com/@t3dotgg/videos"
-				target="_blank"
-				class="text-neutral-100 underline decoration-neutral-700 underline-offset-2 transition-colors hover:decoration-neutral-400"
+		<h1 class="mb-0 pb-0 text-4xl font-bold tracking-tight" style="color: var(--color-text)">
+			Ben Davis
+		</h1>
+		<p class="mx-0 mt-2 mb-8" style="color: var(--color-text-muted)">
+			<a href="https://github.com/bmdavis419" target="_blank" class="brand-link">developer</a>,
+			<a href="https://www.youtube.com/@bmdavis419" target="_blank" class="brand-link">youtuber</a>,
+			and
+			<a href="https://www.youtube.com/@t3dotgg/videos" target="_blank" class="brand-link"
 				>theo's manager</a
 			>. based in sf.
 		</p>
 
-		<h3 class="mb-4 text-lg font-medium text-neutral-200">You might be looking for:</h3>
+		<h3 class="mb-4 text-lg font-medium" style="color: var(--color-text)">
+			You might be looking for:
+		</h3>
 
 		<div class="space-y-3">
-			<a
-				href="/sponsors"
-				class="block rounded-lg border border-neutral-800 bg-neutral-900 p-4 transition-all hover:border-neutral-700 hover:bg-neutral-800/80"
-			>
-				<span class="font-medium text-neutral-100">Sponsors</span>
-				<span class="mt-1 block text-sm text-neutral-400"
+			<a href="/sponsors" class="resource-card">
+				<span class="font-medium" style="color: var(--color-text)">Sponsors</span>
+				<span class="mt-1 block text-sm" style="color: var(--color-text-subtle)"
 					>The companies backing my work, with links, logos, and a quick rundown on each one.</span
 				>
 			</a>
 
-			<a
-				href="https://ai.davis7.sh/"
-				target="_blank"
-				class="block rounded-lg border border-neutral-800 bg-neutral-900 p-4 transition-all hover:border-neutral-700 hover:bg-neutral-800/80"
-			>
-				<span class="font-medium text-neutral-100">My "State of AI"</span>
-				<span class="mt-1 block text-sm text-neutral-400"
+			<a href="https://ai.davis7.sh/" target="_blank" class="resource-card">
+				<span class="font-medium" style="color: var(--color-text)">My "State of AI"</span>
+				<span class="mt-1 block text-sm" style="color: var(--color-text-subtle)"
 					>Rankings + descriptions of the models, harnesses, and subs I'm currently using.
 					Periodically updated</span
 				>
 			</a>
 
-			<a
-				href="/macos"
-				class="block rounded-lg border border-neutral-800 bg-neutral-900 p-4 transition-all hover:border-neutral-700 hover:bg-neutral-800/80"
-			>
-				<span class="font-medium text-neutral-100">My MacOS Setup</span>
-				<span class="mt-1 block text-sm text-neutral-400"
+			<a href="/macos" class="resource-card">
+				<span class="font-medium" style="color: var(--color-text)">My MacOS Setup</span>
+				<span class="mt-1 block text-sm" style="color: var(--color-text-subtle)"
 					>A collection of resources on how I setup my mac to be a power user's dream. Includes
 					karabiner config, keyboard shortcuts, tools I used to make my configs, all the programs I
 					use, and more.</span
 				>
 			</a>
 
-			<a
-				href="/karabiner"
-				class="block rounded-lg border border-neutral-800 bg-neutral-900 p-4 transition-all hover:border-neutral-700 hover:bg-neutral-800/80"
-			>
-				<span class="font-medium text-neutral-100">Karabiner Config</span>
-				<span class="mt-1 block text-sm text-neutral-400"
+			<a href="/karabiner" class="resource-card">
+				<span class="font-medium" style="color: var(--color-text)">Karabiner Config</span>
+				<span class="mt-1 block text-sm" style="color: var(--color-text-subtle)"
 					>My complete karabiner elements config and a visualizer for all my keybindings.</span
 				>
 			</a>
 
-			<a
-				href="/font"
-				class="block rounded-lg border border-neutral-800 bg-neutral-900 p-4 transition-all hover:border-neutral-700 hover:bg-neutral-800/80"
-			>
-				<span class="font-medium text-neutral-100">My Font</span>
-				<span class="mt-1 block text-sm text-neutral-400"
+			<a href="/font" class="resource-card">
+				<span class="font-medium" style="color: var(--color-text)">My Font</span>
+				<span class="mt-1 block text-sm" style="color: var(--color-text-subtle)"
 					>The font I use in Cursor and the terminal</span
 				>
 			</a>
 
-			<a
-				href="https://btca.dev"
-				target="_blank"
-				class="block rounded-lg border border-neutral-800 bg-neutral-900 p-4 transition-all hover:border-neutral-700 hover:bg-neutral-800/80"
-			>
-				<span class="font-medium text-neutral-100">btca (The Better Context App)</span>
-				<span class="mt-1 block text-sm text-neutral-400"
+			<a href="https://btca.dev" target="_blank" class="resource-card">
+				<span class="font-medium" style="color: var(--color-text)"
+					>btca (The Better Context App)</span
+				>
+				<span class="mt-1 block text-sm" style="color: var(--color-text-subtle)"
 					>The best way to get up to date context on the tech you're building with.</span
 				>
 			</a>
 
-			<a
-				href="https://svg.davis7.sh"
-				target="_blank"
-				class="block rounded-lg border border-neutral-800 bg-neutral-900 p-4 transition-all hover:border-neutral-700 hover:bg-neutral-800/80"
-			>
-				<span class="font-medium text-neutral-100">Quick SVG Background</span>
-				<span class="mt-1 block text-sm text-neutral-400"
+			<a href="https://svg.davis7.sh" target="_blank" class="resource-card">
+				<span class="font-medium" style="color: var(--color-text)">Quick SVG Background</span>
+				<span class="mt-1 block text-sm" style="color: var(--color-text-subtle)"
 					>A really simple webapp for uploading an SVG and adding a background to it. I know it
 					sounds dumb, but I use it all the time for making thumbnails.</span
 				>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -25,10 +25,8 @@
 				/>
 			</svg>
 		</div>
-		<h1 class="mb-0 pb-0 text-4xl font-bold tracking-tight" style="color: var(--color-text)">
-			Ben Davis
-		</h1>
-		<p class="mx-0 mt-2 mb-8" style="color: var(--color-text-muted)">
+		<h1 class="headline-text mb-0 pb-0 text-4xl font-bold tracking-tight">Ben Davis</h1>
+		<p class="muted-text mx-0 mt-2 mb-8">
 			<a href="https://github.com/bmdavis419" target="_blank" class="brand-link">developer</a>,
 			<a href="https://www.youtube.com/@bmdavis419" target="_blank" class="brand-link">youtuber</a>,
 			and
@@ -37,29 +35,27 @@
 			>. based in sf.
 		</p>
 
-		<h3 class="mb-4 text-lg font-medium" style="color: var(--color-text)">
-			You might be looking for:
-		</h3>
+		<h3 class="headline-text mb-4 text-lg font-medium">You might be looking for:</h3>
 
 		<div class="space-y-3">
 			<a href="/sponsors" class="resource-card">
-				<span class="font-medium" style="color: var(--color-text)">Sponsors</span>
-				<span class="mt-1 block text-sm" style="color: var(--color-text-subtle)"
+				<span class="resource-title font-medium">Sponsors</span>
+				<span class="resource-subtitle mt-1 block text-sm"
 					>The companies backing my work, with links, logos, and a quick rundown on each one.</span
 				>
 			</a>
 
 			<a href="https://ai.davis7.sh/" target="_blank" class="resource-card">
-				<span class="font-medium" style="color: var(--color-text)">My "State of AI"</span>
-				<span class="mt-1 block text-sm" style="color: var(--color-text-subtle)"
+				<span class="resource-title font-medium">My "State of AI"</span>
+				<span class="resource-subtitle mt-1 block text-sm"
 					>Rankings + descriptions of the models, harnesses, and subs I'm currently using.
 					Periodically updated</span
 				>
 			</a>
 
 			<a href="/macos" class="resource-card">
-				<span class="font-medium" style="color: var(--color-text)">My MacOS Setup</span>
-				<span class="mt-1 block text-sm" style="color: var(--color-text-subtle)"
+				<span class="resource-title font-medium">My MacOS Setup</span>
+				<span class="resource-subtitle mt-1 block text-sm"
 					>A collection of resources on how I setup my mac to be a power user's dream. Includes
 					karabiner config, keyboard shortcuts, tools I used to make my configs, all the programs I
 					use, and more.</span
@@ -67,31 +63,29 @@
 			</a>
 
 			<a href="/karabiner" class="resource-card">
-				<span class="font-medium" style="color: var(--color-text)">Karabiner Config</span>
-				<span class="mt-1 block text-sm" style="color: var(--color-text-subtle)"
+				<span class="resource-title font-medium">Karabiner Config</span>
+				<span class="resource-subtitle mt-1 block text-sm"
 					>My complete karabiner elements config and a visualizer for all my keybindings.</span
 				>
 			</a>
 
 			<a href="/font" class="resource-card">
-				<span class="font-medium" style="color: var(--color-text)">My Font</span>
-				<span class="mt-1 block text-sm" style="color: var(--color-text-subtle)"
+				<span class="resource-title font-medium">My Font</span>
+				<span class="resource-subtitle mt-1 block text-sm"
 					>The font I use in Cursor and the terminal</span
 				>
 			</a>
 
 			<a href="https://btca.dev" target="_blank" class="resource-card">
-				<span class="font-medium" style="color: var(--color-text)"
-					>btca (The Better Context App)</span
-				>
-				<span class="mt-1 block text-sm" style="color: var(--color-text-subtle)"
+				<span class="resource-title font-medium">btca (The Better Context App)</span>
+				<span class="resource-subtitle mt-1 block text-sm"
 					>The best way to get up to date context on the tech you're building with.</span
 				>
 			</a>
 
 			<a href="https://svg.davis7.sh" target="_blank" class="resource-card">
-				<span class="font-medium" style="color: var(--color-text)">Quick SVG Background</span>
-				<span class="mt-1 block text-sm" style="color: var(--color-text-subtle)"
+				<span class="resource-title font-medium">Quick SVG Background</span>
+				<span class="resource-subtitle mt-1 block text-sm"
 					>A really simple webapp for uploading an SVG and adding a background to it. I know it
 					sounds dumb, but I use it all the time for making thumbnails.</span
 				>

--- a/src/routes/font/+page.svelte
+++ b/src/routes/font/+page.svelte
@@ -9,16 +9,12 @@
 
 <main class="px-3">
 	<div class="pb-16">
-		<a
-			href="/"
-			class="mb-6 inline-flex text-sm text-neutral-400 underline decoration-neutral-800 underline-offset-4 transition-colors hover:text-neutral-200 hover:decoration-neutral-500"
-		>
-			Back home
-		</a>
+		<a href="/" class="back-link mb-6"> Back home </a>
 
 		<div class="mt-12 mb-10 flex flex-col items-center gap-4 text-center sm:mt-20 sm:mb-14">
 			<h1
-				class="text-[clamp(2.5rem,5vw,4rem)] leading-[1.1] font-bold tracking-tight text-neutral-100"
+				class="text-[clamp(2.5rem,5vw,4rem)] leading-[1.1] font-bold tracking-tight"
+				style="color: var(--color-text)"
 			>
 				What Font is That?
 			</h1>
@@ -27,25 +23,23 @@
 				href="https://usgraphics.com/products/berkeley-mono"
 				target="_blank"
 				rel="noreferrer"
-				class="text-lg text-neutral-100 underline decoration-neutral-700 underline-offset-4 transition-colors hover:decoration-neutral-400 sm:text-xl"
+				class="brand-link text-lg sm:text-xl"
 			>
 				Berkeley Mono
 			</a>
 
-			<p class="text-sm text-neutral-400 sm:text-base">
+			<p class="text-sm sm:text-base" style="color: var(--color-text-subtle)">
 				(and the theme is <a
 					href="https://open-vsx.org/extension/GitHub/github-vscode-theme"
 					target="_blank"
 					rel="noreferrer"
-					class="text-neutral-300 underline decoration-neutral-700 underline-offset-2 transition-colors hover:decoration-neutral-400"
-					>GitHub Dark Default</a
+					class="brand-link">GitHub Dark Default</a
 				>, the icons are
 				<a
 					href="https://open-vsx.org/extension/vscode-icons-team/vscode-icons"
 					target="_blank"
 					rel="noreferrer"
-					class="text-neutral-300 underline decoration-neutral-700 underline-offset-2 transition-colors hover:decoration-neutral-400"
-					>VSCode Icons</a
+					class="brand-link">VSCode Icons</a
 				>)
 			</p>
 		</div>
@@ -54,7 +48,8 @@
 			<img
 				src="/font-showcase.png"
 				alt="Berkeley Mono font showcase"
-				class="w-full rounded-xl border border-neutral-800 shadow-2xl shadow-black/50"
+				class="w-full border shadow-2xl shadow-black/35"
+				style="border-color: var(--color-border)"
 			/>
 		</div>
 	</div>

--- a/src/routes/karabiner/+page.svelte
+++ b/src/routes/karabiner/+page.svelte
@@ -53,59 +53,77 @@
 </svelte:head>
 
 <div class="flex flex-col items-start gap-8">
-	<a
-		href="/"
-		class="mb-2 text-sm font-medium text-neutral-400 transition-colors hover:text-neutral-300"
-		>← Back to Home</a
-	>
-	<h2 class="text-2xl font-semibold text-neutral-100">My Karabiner Config</h2>
+	<a href="/" class="back-link mb-2">← Back to Home</a>
+	<h2 class="text-2xl font-semibold" style="color: var(--color-text)">My Karabiner Config</h2>
 
-	<p class="leading-relaxed text-neutral-300">
+	<p class="leading-relaxed" style="color: var(--color-text-muted)">
 		This is my "hyper key" config, you can download Karabiner elements
 		<a
 			href="https://karabiner-elements.pqrs.org/"
 			target="_blank"
 			rel="noopener noreferrer"
-			class="text-neutral-100 underline transition-colors hover:text-neutral-50">here</a
+			class="brand-link">here</a
 		>.
 	</p>
 
-	<button
-		class="rounded-lg border-2 border-blue-500 bg-transparent px-4 py-2 font-medium text-blue-300 transition-all hover:border-blue-400 hover:text-blue-200"
-		onclick={() => (showModal = true)}
-	>
-		View Full Config
-	</button>
+	<button class="button" onclick={() => (showModal = true)}> View Full Config </button>
 
 	<Keyboard />
 
-	<p class="text-neutral-300">Keybindings:</p>
+	<p style="color: var(--color-text-muted)">Keybindings:</p>
 	<ul class="w-full space-y-2 font-bold">
-		<li class="border-b border-neutral-800 py-2 text-neutral-300 last:border-b-0">
+		<li
+			class="border-b py-2 last:border-b-0"
+			style="border-color: var(--color-border); color: var(--color-text-muted)"
+		>
 			Caps Lock to Hyper
 		</li>
-		<li class="border-b border-neutral-800 py-2 text-neutral-300 last:border-b-0">
+		<li
+			class="border-b py-2 last:border-b-0"
+			style="border-color: var(--color-border); color: var(--color-text-muted)"
+		>
 			Hyper + tab to control + tab
 		</li>
-		<li class="border-b border-neutral-800 py-2 text-neutral-300 last:border-b-0">
+		<li
+			class="border-b py-2 last:border-b-0"
+			style="border-color: var(--color-border); color: var(--color-text-muted)"
+		>
 			Hyper + a to cmd + a
 		</li>
-		<li class="border-b border-neutral-800 py-2 text-neutral-300 last:border-b-0">
+		<li
+			class="border-b py-2 last:border-b-0"
+			style="border-color: var(--color-border); color: var(--color-text-muted)"
+		>
 			Hyper + j/k to pageup/pagedown
 		</li>
-		<li class="border-b border-neutral-800 py-2 text-neutral-300 last:border-b-0">
+		<li
+			class="border-b py-2 last:border-b-0"
+			style="border-color: var(--color-border); color: var(--color-text-muted)"
+		>
 			Hyper + h/l to left/right arrow
 		</li>
-		<li class="border-b border-neutral-800 py-2 text-neutral-300 last:border-b-0">
+		<li
+			class="border-b py-2 last:border-b-0"
+			style="border-color: var(--color-border); color: var(--color-text-muted)"
+		>
 			Hyper + c to cmd + c
 		</li>
-		<li class="border-b border-neutral-800 py-2 text-neutral-300 last:border-b-0">
+		<li
+			class="border-b py-2 last:border-b-0"
+			style="border-color: var(--color-border); color: var(--color-text-muted)"
+		>
 			Hyper + v to cmd + v
 		</li>
-		<li class="border-b border-neutral-800 py-2 text-neutral-300 last:border-b-0">
+		<li
+			class="border-b py-2 last:border-b-0"
+			style="border-color: var(--color-border); color: var(--color-text-muted)"
+		>
 			Hyper + t to cmd + t
 		</li>
-		<li class="border-b border-neutral-800 py-2 text-neutral-300 last:border-b-0">
+		<li
+			class="border-b py-2 last:border-b-0"
+			style="border-color: var(--color-border); color: var(--color-text-muted)"
+		>
 			Hyper + w to cmd + w
 		</li>
 	</ul>
@@ -115,28 +133,20 @@
 	<!-- svelte-ignore a11y_click_events_have_key_events -->
 	<!-- svelte-ignore a11y_no_static_element_interactions -->
 	<div
-		class="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+		class="fixed inset-0 z-50 flex items-center justify-center bg-black/55"
 		onclick={() => (showModal = false)}
 	>
-		<div
-			class="z-50 max-h-[90vh] max-w-4xl overflow-auto rounded-lg border border-neutral-800 bg-neutral-900 p-6"
-		>
+		<div class="surface z-50 max-h-[90vh] max-w-4xl overflow-auto p-6">
 			<div class="mb-4 flex items-center justify-between">
-				<h3 class="text-xl font-semibold text-neutral-100">Full Karabiner Configuration</h3>
-				<button
-					class="text-neutral-400 transition-colors hover:text-neutral-100"
-					onclick={() => (showModal = false)}
-				>
-					✕
-				</button>
+				<h3 class="text-xl font-semibold" style="color: var(--color-text)">
+					Full Karabiner Configuration
+				</h3>
+				<button class="icon-button h-8 w-8" onclick={() => (showModal = false)}> ✕ </button>
 			</div>
 			<div class="mb-4">
-				<button
-					class="flex items-center gap-2 rounded-lg border-2 border-blue-500 bg-transparent px-3 py-2 font-medium text-blue-300 transition-all hover:border-blue-400 hover:text-blue-200"
-					onclick={copy}
-				>
+				<button class="button" onclick={copy}>
 					{#if copied}
-						<Check size={16} class="text-green-400" />
+						<Check size={16} class="success-text" />
 						Copied!
 					{:else}
 						<Copy size={16} />
@@ -144,7 +154,7 @@
 					{/if}
 				</button>
 			</div>
-			<div class="rounded-lg bg-neutral-800 p-4 text-sm">
+			<div class="surface p-4 text-sm">
 				{@html html}
 			</div>
 		</div>

--- a/src/routes/karabiner/+page.svelte
+++ b/src/routes/karabiner/+page.svelte
@@ -39,12 +39,16 @@
 		run();
 	});
 
-	const copy = () => {
-		navigator.clipboard.writeText(JSON.stringify(myConfig));
-		copied = true;
-		setTimeout(() => {
+	const copy = async () => {
+		try {
+			await navigator.clipboard.writeText(JSON.stringify(myConfig));
+			copied = true;
+			setTimeout(() => {
+				copied = false;
+			}, 2000);
+		} catch {
 			copied = false;
-		}, 2000);
+		}
 	};
 </script>
 
@@ -136,7 +140,10 @@
 		class="fixed inset-0 z-50 flex items-center justify-center bg-black/55"
 		onclick={() => (showModal = false)}
 	>
-		<div class="surface z-50 max-h-[90vh] max-w-4xl overflow-auto p-6">
+		<div
+			class="surface z-50 max-h-[90vh] max-w-4xl overflow-auto p-6"
+			onclick={(event) => event.stopPropagation()}
+		>
 			<div class="mb-4 flex items-center justify-between">
 				<h3 class="text-xl font-semibold" style="color: var(--color-text)">
 					Full Karabiner Configuration

--- a/src/routes/macos/+page.svelte
+++ b/src/routes/macos/+page.svelte
@@ -48,11 +48,7 @@ My tmux config is located at: ~/.tmux.conf Your job is to make the changes I des
 
 <main class="z-10 px-3 text-center">
 	<article class="prose prose-neutral pb-16 text-left">
-		<a
-			href="/"
-			class="mb-8 inline-block text-sm font-medium text-neutral-400 transition-colors hover:text-neutral-300"
-			>← Back to Home</a
-		>
+		<a href="/" class="back-link mb-8">← Back to Home</a>
 
 		<h1 class="mb-8">MacOS Power User Setup</h1>
 
@@ -115,11 +111,11 @@ My tmux config is located at: ~/.tmux.conf Your job is to make the changes I des
 
 		<div class="relative">
 			<button
-				class="absolute top-2 right-2 flex items-center gap-1 rounded border border-neutral-600 bg-neutral-800 px-2 py-1 text-xs font-medium text-neutral-300 transition-colors hover:border-neutral-500 hover:text-neutral-200"
+				class="button absolute top-2 right-2 px-2 py-1 text-xs"
 				onclick={() => copyToClipboard(ghosttyContent, 'ghostty')}
 			>
 				{#if copiedId === 'ghostty'}
-					<Check size={12} class="text-green-400" />
+					<Check size={12} class="success-text" />
 					Copied!
 				{:else}
 					<Copy size={12} />
@@ -141,11 +137,11 @@ Run "ghostty +show-config --default --docs" to see the full guide on how to conf
 
 		<div class="relative">
 			<button
-				class="absolute top-2 right-2 flex items-center gap-1 rounded border border-neutral-600 bg-neutral-800 px-2 py-1 text-xs font-medium text-neutral-300 transition-colors hover:border-neutral-500 hover:text-neutral-200"
+				class="button absolute top-2 right-2 px-2 py-1 text-xs"
 				onclick={() => copyToClipboard(cursorContent, 'cursor')}
 			>
 				{#if copiedId === 'cursor'}
-					<Check size={12} class="text-green-400" />
+					<Check size={12} class="success-text" />
 					Copied!
 				{:else}
 					<Copy size={12} />
@@ -167,11 +163,11 @@ My cursor (vscode) keybindings are located at: "~/Library/Application Support/Cu
 
 		<div class="relative">
 			<button
-				class="absolute top-2 right-2 flex items-center gap-1 rounded border border-neutral-600 bg-neutral-800 px-2 py-1 text-xs font-medium text-neutral-300 transition-colors hover:border-neutral-500 hover:text-neutral-200"
+				class="button absolute top-2 right-2 px-2 py-1 text-xs"
 				onclick={() => copyToClipboard(tmuxContent, 'tmux')}
 			>
 				{#if copiedId === 'tmux'}
-					<Check size={12} class="text-green-400" />
+					<Check size={12} class="success-text" />
 					Copied!
 				{:else}
 					<Copy size={12} />

--- a/src/routes/og/+page.svelte
+++ b/src/routes/og/+page.svelte
@@ -10,7 +10,7 @@
 			margin: 0;
 			padding: 0;
 			overflow: hidden;
-			background: #000;
+			background: #0b0d10;
 		}
 		/* override the site layout to center the card */
 		body > div > div {
@@ -51,7 +51,7 @@
 	.og-card {
 		width: 1200px;
 		height: 630px;
-		background: #0a0a0a;
+		background: #0b0d10;
 		position: relative;
 		overflow: hidden;
 		font-family:
@@ -67,6 +67,7 @@
 		background-image: url('/grid.svg');
 		background-repeat: repeat;
 		background-size: 24px 24px;
+		opacity: 0.9;
 		/* diagonal fade: transparent top-left, visible bottom-right */
 		mask-image: linear-gradient(
 			135deg,
@@ -82,7 +83,6 @@
 			rgba(0, 0, 0, 0.6) 70%,
 			rgba(0, 0, 0, 1) 100%
 		);
-		opacity: 1;
 	}
 
 	/* subtle radial glow in bottom-right to warm the grid area */
@@ -93,7 +93,7 @@
 		right: -80px;
 		width: 600px;
 		height: 600px;
-		background: radial-gradient(circle, rgba(255, 255, 255, 0.02) 0%, transparent 70%);
+		background: radial-gradient(circle, rgba(0, 184, 217, 0.06) 0%, transparent 68%);
 		pointer-events: none;
 		z-index: 1;
 	}
@@ -133,8 +133,8 @@
 		margin: 0;
 		font-size: 52px;
 		font-weight: 700;
-		letter-spacing: -0.03em;
-		color: #fafafa;
+		letter-spacing: 0;
+		color: #f5f6f7;
 		line-height: 1.1;
 	}
 
@@ -142,9 +142,9 @@
 		margin: 0;
 		font-size: 22px;
 		font-weight: 400;
-		color: #737373;
+		color: #b8bec7;
 		line-height: 1.4;
-		letter-spacing: -0.01em;
+		letter-spacing: 0;
 	}
 
 	.og-bottom {
@@ -155,7 +155,7 @@
 	.og-domain {
 		font-size: 18px;
 		font-weight: 500;
-		color: #404040;
+		color: #838b96;
 		letter-spacing: 0.02em;
 	}
 </style>

--- a/src/routes/sponsors/+page.svelte
+++ b/src/routes/sponsors/+page.svelte
@@ -79,19 +79,15 @@
 
 <main class="px-3">
 	<div class="pb-16">
-		<a
-			href="/"
-			class="mb-6 inline-flex text-sm text-neutral-400 underline decoration-neutral-800 underline-offset-4 transition-colors hover:text-neutral-200 hover:decoration-neutral-500"
-		>
-			Back home
-		</a>
+		<a href="/" class="back-link mb-6"> Back home </a>
 
 		<h1
-			class="text-[clamp(2.25rem,4vw,3.75rem)] leading-none font-bold tracking-tight text-neutral-100"
+			class="text-[clamp(2.25rem,4vw,3.75rem)] leading-none font-bold tracking-tight"
+			style="color: var(--color-text)"
 		>
 			Sponsors
 		</h1>
-		<p class="mt-3 max-w-2xl text-base leading-7 text-neutral-300 sm:text-lg">
+		<p class="mt-3 max-w-2xl text-base leading-7 sm:text-lg" style="color: var(--color-text-muted)">
 			The companies I wanted to work with to make my videos possible.
 		</p>
 
@@ -134,20 +130,24 @@
 
 <style lang="postcss">
 	.sponsor-card {
-		--sponsor-surface: linear-gradient(180deg, #0a0a0a 0%, #111111 100%);
-		--sponsor-surface-hover: linear-gradient(180deg, #0b0b0b 0%, #181818 100%);
-		--sponsor-border: rgba(255, 255, 255, 0.12);
-		--sponsor-border-hover: rgba(255, 255, 255, 0.24);
-		--sponsor-logo-bg: #050505;
-		--sponsor-logo-border: rgba(255, 255, 255, 0.08);
-		--sponsor-logo-border-hover: rgba(255, 255, 255, 0.18);
-		--sponsor-title: var(--color-neutral-100);
-		--sponsor-description: var(--color-neutral-300);
-		--sponsor-cta: var(--color-neutral-100);
+		--sponsor-accent: var(--color-accent-cyan);
+		--sponsor-accent-soft: color-mix(in srgb, var(--sponsor-accent) 18%, transparent);
+		--sponsor-surface: var(--color-surface);
+		--sponsor-surface-hover: var(--color-surface-elevated);
+		--sponsor-border: var(--color-border);
+		--sponsor-border-hover: color-mix(in srgb, var(--sponsor-accent) 34%, var(--color-border));
+		--sponsor-logo-bg: var(--color-ink);
+		--sponsor-logo-border: color-mix(in srgb, var(--sponsor-accent) 18%, var(--color-border));
+		--sponsor-logo-border-hover: color-mix(in srgb, var(--sponsor-accent) 34%, var(--color-border));
+		--sponsor-title: var(--color-text);
+		--sponsor-description: var(--color-text-muted);
+		--sponsor-cta: var(--sponsor-accent);
 		background: var(--sponsor-surface);
 		border: 1px solid var(--sponsor-border);
 		color: var(--sponsor-title);
-		box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.03);
+		box-shadow:
+			var(--shadow-surface),
+			inset 0 2px 0 var(--sponsor-accent-soft);
 		transition:
 			transform 180ms ease,
 			background 180ms ease,
@@ -159,7 +159,9 @@
 		transform: translateY(-2px);
 		background: var(--sponsor-surface-hover);
 		border-color: var(--sponsor-border-hover);
-		box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.05);
+		box-shadow:
+			var(--shadow-surface),
+			inset 0 2px 0 color-mix(in srgb, var(--sponsor-accent) 42%, transparent);
 	}
 
 	.sponsor-logo-frame {
@@ -188,129 +190,33 @@
 	}
 
 	.sponsor-card--agentuity {
-		--sponsor-surface: linear-gradient(180deg, #081214 0%, #091a1d 100%);
-		--sponsor-surface-hover: linear-gradient(180deg, #091619 0%, #0d2327 100%);
-		--sponsor-border: rgba(34, 211, 238, 0.18);
-		--sponsor-border-hover: rgba(34, 211, 238, 0.32);
-		--sponsor-logo-border: rgba(34, 211, 238, 0.16);
-		--sponsor-logo-border-hover: rgba(34, 211, 238, 0.28);
-		--sponsor-cta: #22d3ee;
+		--sponsor-accent: var(--color-accent-cyan);
 	}
 
 	.sponsor-card--daytona {
-		--sponsor-surface: linear-gradient(180deg, #0b0b0b 0%, #131313 100%);
-		--sponsor-surface-hover: linear-gradient(180deg, #0d0d0d 0%, #1a1a1a 100%);
-		--sponsor-border: rgba(255, 255, 255, 0.14);
-		--sponsor-border-hover: rgba(255, 255, 255, 0.28);
-		--sponsor-logo-border: rgba(255, 255, 255, 0.08);
-		--sponsor-logo-border-hover: rgba(255, 255, 255, 0.2);
-		--sponsor-cta: var(--color-neutral-50);
+		--sponsor-accent: var(--color-cloud);
 	}
 
 	.sponsor-card--railway {
-		--sponsor-surface: linear-gradient(180deg, #120a1b 0%, #1a1226 100%);
-		--sponsor-surface-hover: linear-gradient(180deg, #140c1f 0%, #20142d 100%);
-		--sponsor-border: rgba(168, 85, 247, 0.18);
-		--sponsor-border-hover: rgba(168, 85, 247, 0.34);
-		--sponsor-logo-border: rgba(168, 85, 247, 0.16);
-		--sponsor-logo-border-hover: rgba(168, 85, 247, 0.28);
-		--sponsor-cta: #c084fc;
+		--sponsor-accent: var(--color-context-violet);
 	}
 
 	.sponsor-card--greptile {
-		--sponsor-surface: linear-gradient(180deg, #07130f 0%, #0b1d16 100%);
-		--sponsor-surface-hover: linear-gradient(180deg, #081611 0%, #0f2820 100%);
-		--sponsor-border: rgba(16, 185, 129, 0.18);
-		--sponsor-border-hover: rgba(16, 185, 129, 0.34);
-		--sponsor-logo-border: rgba(16, 185, 129, 0.16);
-		--sponsor-logo-border-hover: rgba(16, 185, 129, 0.28);
-		--sponsor-cta: #34d399;
+		--sponsor-accent: var(--color-success);
 	}
 
 	.sponsor-card--upstash {
-		--sponsor-surface: linear-gradient(180deg, #07120c 0%, #0b1a12 100%);
-		--sponsor-surface-hover: linear-gradient(180deg, #091710 0%, #0f2418 100%);
-		--sponsor-border: rgba(16, 185, 129, 0.18);
-		--sponsor-border-hover: rgba(16, 185, 129, 0.34);
-		--sponsor-logo-border: rgba(16, 185, 129, 0.16);
-		--sponsor-logo-border-hover: rgba(16, 185, 129, 0.28);
-		--sponsor-cta: #34d399;
+		--sponsor-accent: var(--color-success);
 	}
 
 	.sponsor-card--workos {
-		--sponsor-surface: linear-gradient(180deg, #0a0d1d 0%, #101632 100%);
-		--sponsor-surface-hover: linear-gradient(180deg, #0b1022 0%, #161c3f 100%);
-		--sponsor-border: rgba(99, 102, 241, 0.18);
-		--sponsor-border-hover: rgba(99, 102, 241, 0.34);
-		--sponsor-logo-border: rgba(99, 102, 241, 0.16);
-		--sponsor-logo-border-hover: rgba(99, 102, 241, 0.28);
-		--sponsor-cta: #a5b4fc;
-	}
-
-	:global(html[data-theme='light']) .sponsor-card--agentuity {
-		--sponsor-surface: linear-gradient(180deg, #ffffff 0%, #f0fdfa 100%);
-		--sponsor-surface-hover: linear-gradient(180deg, #ffffff 0%, #ecfeff 100%);
-		--sponsor-border: rgba(34, 211, 238, 0.18);
-		--sponsor-border-hover: rgba(34, 211, 238, 0.3);
-		--sponsor-logo-border: rgba(34, 211, 238, 0.14);
-		--sponsor-logo-border-hover: rgba(34, 211, 238, 0.24);
-		--sponsor-cta: #0891b2;
-	}
-
-	:global(html[data-theme='light']) .sponsor-card--daytona {
-		--sponsor-surface: linear-gradient(180deg, #ffffff 0%, #f4f4f5 100%);
-		--sponsor-surface-hover: linear-gradient(180deg, #ffffff 0%, #e7e7ea 100%);
-		--sponsor-border: rgba(24, 24, 27, 0.12);
-		--sponsor-border-hover: rgba(24, 24, 27, 0.22);
-		--sponsor-logo-border: rgba(24, 24, 27, 0.1);
-		--sponsor-logo-border-hover: rgba(24, 24, 27, 0.18);
-		--sponsor-cta: #171717;
-	}
-
-	:global(html[data-theme='light']) .sponsor-card--railway {
-		--sponsor-surface: linear-gradient(180deg, #ffffff 0%, #f7f2ff 100%);
-		--sponsor-surface-hover: linear-gradient(180deg, #ffffff 0%, #f1e7ff 100%);
-		--sponsor-border: rgba(168, 85, 247, 0.18);
-		--sponsor-border-hover: rgba(168, 85, 247, 0.3);
-		--sponsor-logo-border: rgba(168, 85, 247, 0.14);
-		--sponsor-logo-border-hover: rgba(168, 85, 247, 0.24);
-		--sponsor-cta: #7c3aed;
-	}
-
-	:global(html[data-theme='light']) .sponsor-card--greptile {
-		--sponsor-surface: linear-gradient(180deg, #ffffff 0%, #f0fdf4 100%);
-		--sponsor-surface-hover: linear-gradient(180deg, #ffffff 0%, #dcfce7 100%);
-		--sponsor-border: rgba(16, 185, 129, 0.18);
-		--sponsor-border-hover: rgba(16, 185, 129, 0.3);
-		--sponsor-logo-border: rgba(16, 185, 129, 0.14);
-		--sponsor-logo-border-hover: rgba(16, 185, 129, 0.24);
-		--sponsor-cta: #059669;
-	}
-
-	:global(html[data-theme='light']) .sponsor-card--upstash {
-		--sponsor-surface: linear-gradient(180deg, #ffffff 0%, #ecfdf5 100%);
-		--sponsor-surface-hover: linear-gradient(180deg, #ffffff 0%, #d1fae5 100%);
-		--sponsor-border: rgba(16, 185, 129, 0.18);
-		--sponsor-border-hover: rgba(16, 185, 129, 0.3);
-		--sponsor-logo-border: rgba(16, 185, 129, 0.14);
-		--sponsor-logo-border-hover: rgba(16, 185, 129, 0.24);
-		--sponsor-cta: #059669;
-	}
-
-	:global(html[data-theme='light']) .sponsor-card--workos {
-		--sponsor-surface: linear-gradient(180deg, #ffffff 0%, #eef2ff 100%);
-		--sponsor-surface-hover: linear-gradient(180deg, #ffffff 0%, #e0e7ff 100%);
-		--sponsor-border: rgba(99, 102, 241, 0.18);
-		--sponsor-border-hover: rgba(99, 102, 241, 0.3);
-		--sponsor-logo-border: rgba(99, 102, 241, 0.14);
-		--sponsor-logo-border-hover: rgba(99, 102, 241, 0.24);
-		--sponsor-cta: #4f46e5;
+		--sponsor-accent: var(--color-context-violet);
 	}
 
 	/* Keep logo frame dark in light mode so white SVG logos remain visible */
 	:global(html[data-theme='light']) .sponsor-card {
 		--sponsor-logo-bg: #1a1a1a;
-		--sponsor-title: var(--color-neutral-100);
-		--sponsor-description: var(--color-neutral-300);
+		--sponsor-title: var(--color-text);
+		--sponsor-description: var(--color-text-muted);
 	}
 </style>

--- a/src/routes/sponsors/+page.svelte
+++ b/src/routes/sponsors/+page.svelte
@@ -197,6 +197,10 @@
 		--sponsor-accent: var(--color-cloud);
 	}
 
+	:global(html[data-theme='light']) .sponsor-card--daytona {
+		--sponsor-accent: var(--color-text);
+	}
+
 	.sponsor-card--railway {
 		--sponsor-accent: var(--color-context-violet);
 	}

--- a/src/routes/sv/+page.svelte
+++ b/src/routes/sv/+page.svelte
@@ -9,10 +9,10 @@
 	let helloWorld = $state(false);
 	let convexSetup = $state(false);
 	let vscodeThemeEnabled = $state(false);
-	let topBarColor = $state('#1f2937');
+	let topBarColor = $state('#232831');
 	let topBarTextColor = $state('#ffffff');
 	let tailwindThemeEnabled = $state(false);
-	let primaryColor = $state('#f97316');
+	let primaryColor = $state('#00B8D9');
 
 	let toastMessage = $state<string | null>(null);
 	let toastType = $state<'success' | 'error'>('success');
@@ -97,28 +97,18 @@
 
 <div class="w-full max-w-2xl space-y-8 px-3">
 	<div class="space-y-4">
-		<a
-			href="/"
-			class="mb-4 inline-block text-sm font-medium text-neutral-400 transition-colors hover:text-neutral-300"
-			>← Back to Home</a
-		>
+		<a href="/" class="back-link mb-4">← Back to Home</a>
 		<div class="flex items-center justify-between">
-			<h1 class="text-4xl font-bold text-neutral-50">SvelteKit Setup</h1>
-			<button
-				onclick={toggleAll}
-				class="rounded-lg border border-neutral-600 px-3 py-1 text-sm font-medium text-neutral-300 transition-colors hover:border-neutral-500 hover:text-neutral-200"
-			>
-				Toggle All
-			</button>
+			<h1 class="text-4xl font-bold" style="color: var(--color-text)">SvelteKit Setup</h1>
+			<button onclick={toggleAll} class="button px-3 py-1"> Toggle All </button>
 		</div>
-		<p class="text-lg text-neutral-300">
+		<p class="text-lg" style="color: var(--color-text-muted)">
 			An easy way to setup your SvelteKit project. Select the options you want to enable and copy
 			the prompts to your clipboard, then paste them into cursor.
 		</p>
-		<p class="text-lg text-neutral-300">
+		<p class="text-lg" style="color: var(--color-text-muted)">
 			This will not create a project for you, to do that run: <code
-				class="rounded-md bg-neutral-800 px-2 py-1 font-mono text-sm text-neutral-200"
-				>bunx sv create</code
+				class="code-chip px-2 py-1 font-mono text-sm">bunx sv create</code
 			>. I recommend picking: minimal, typescript, prettier/tailwindcss, and then bun.
 		</p>
 	</div>
@@ -126,113 +116,87 @@
 	<div class="space-y-8">
 		<!-- Basic Prompts -->
 		<div class="space-y-4">
-			<h2 class="text-sm font-semibold tracking-wide text-neutral-400 uppercase">Setup Options</h2>
+			<h2
+				class="text-sm font-semibold tracking-wide uppercase"
+				style="color: var(--color-text-subtle)"
+			>
+				Setup Options
+			</h2>
 			<div class="space-y-1">
-				<label
-					class="flex cursor-pointer items-start gap-3 rounded-lg p-3 transition-colors hover:bg-neutral-900/50"
-				>
+				<label class="option-row">
 					<input
 						type="checkbox"
 						checked={vercelSetup}
 						onchange={(e) => handleVercelChange(e.currentTarget.checked)}
-						class="mt-0.5 h-5 w-5 shrink-0 cursor-pointer rounded border-neutral-600 text-blue-500"
+						class="option-checkbox"
 					/>
 					<div>
-						<span class="text-sm font-medium text-neutral-200">Vercel Setup</span>
-						<p class="mt-0.5 text-xs text-neutral-400">
+						<span class="text-sm font-medium" style="color: var(--color-text)">Vercel Setup</span>
+						<p class="mt-0.5 text-xs" style="color: var(--color-text-subtle)">
 							Adds the vercel adapter and removes the default one
 						</p>
 					</div>
 				</label>
-				<label
-					class="flex cursor-pointer items-start gap-3 rounded-lg p-3 transition-colors hover:bg-neutral-900/50"
-				>
+				<label class="option-row">
 					<input
 						type="checkbox"
 						checked={cloudflareSetup}
 						onchange={(e) => handleCloudflareChange(e.currentTarget.checked)}
-						class="mt-0.5 h-5 w-5 shrink-0 cursor-pointer rounded border-neutral-600 text-blue-500"
+						class="option-checkbox"
 					/>
 					<div>
-						<span class="text-sm font-medium text-neutral-200">Cloudflare Setup</span>
-						<p class="mt-0.5 text-xs text-neutral-400">
+						<span class="text-sm font-medium" style="color: var(--color-text)"
+							>Cloudflare Setup</span
+						>
+						<p class="mt-0.5 text-xs" style="color: var(--color-text-subtle)">
 							Adds the cloudflare adapter, sets up wrangler, and gives you the right commands to
 							deploy to cloudflare
 						</p>
 					</div>
 				</label>
-				<label
-					class="flex cursor-pointer items-start gap-3 rounded-lg p-3 transition-colors hover:bg-neutral-900/50"
-				>
-					<input
-						type="checkbox"
-						bind:checked={convexSetup}
-						class="mt-0.5 h-5 w-5 shrink-0 cursor-pointer rounded border-neutral-600 text-blue-500"
-					/>
+				<label class="option-row">
+					<input type="checkbox" bind:checked={convexSetup} class="option-checkbox" />
 					<div>
-						<span class="text-sm font-medium text-neutral-200">Convex Setup</span>
-						<p class="mt-0.5 text-xs text-neutral-400">
+						<span class="text-sm font-medium" style="color: var(--color-text)">Convex Setup</span>
+						<p class="mt-0.5 text-xs" style="color: var(--color-text-subtle)">
 							Sets up convex in your sveltekit app and gives you a good cursor rule for it
 						</p>
 					</div>
 				</label>
-				<label
-					class="flex cursor-pointer items-start gap-3 rounded-lg p-3 transition-colors hover:bg-neutral-900/50"
-				>
-					<input
-						type="checkbox"
-						bind:checked={cursorRules}
-						class="mt-0.5 h-5 w-5 shrink-0 cursor-pointer rounded border-neutral-600 text-blue-500"
-					/>
+				<label class="option-row">
+					<input type="checkbox" bind:checked={cursorRules} class="option-checkbox" />
 					<div>
-						<span class="text-sm font-medium text-neutral-200">Cursor Rules</span>
-						<p class="mt-0.5 text-xs text-neutral-400">
+						<span class="text-sm font-medium" style="color: var(--color-text)">Cursor Rules</span>
+						<p class="mt-0.5 text-xs" style="color: var(--color-text-subtle)">
 							Adds 5 useful cursor rules for sveltekit: global, neverthrow, svelte, tailwindcss, and
 							convex
 						</p>
 					</div>
 				</label>
-				<label
-					class="flex cursor-pointer items-start gap-3 rounded-lg p-3 transition-colors hover:bg-neutral-900/50"
-				>
-					<input
-						type="checkbox"
-						bind:checked={usefulPackages}
-						class="mt-0.5 h-5 w-5 shrink-0 cursor-pointer rounded border-neutral-600 text-blue-500"
-					/>
+				<label class="option-row">
+					<input type="checkbox" bind:checked={usefulPackages} class="option-checkbox" />
 					<div>
-						<span class="text-sm font-medium text-neutral-200">Useful Packages</span>
-						<p class="mt-0.5 text-xs text-neutral-400">
+						<span class="text-sm font-medium" style="color: var(--color-text)">Useful Packages</span
+						>
+						<p class="mt-0.5 text-xs" style="color: var(--color-text-subtle)">
 							Adds useful packages for sveltekit: runed, neverthrow, and zod
 						</p>
 					</div>
 				</label>
-				<label
-					class="flex cursor-pointer items-start gap-3 rounded-lg p-3 transition-colors hover:bg-neutral-900/50"
-				>
-					<input
-						type="checkbox"
-						bind:checked={asyncSvelte}
-						class="mt-0.5 h-5 w-5 shrink-0 cursor-pointer rounded border-neutral-600 text-blue-500"
-					/>
+				<label class="option-row">
+					<input type="checkbox" bind:checked={asyncSvelte} class="option-checkbox" />
 					<div>
-						<span class="text-sm font-medium text-neutral-200">Async Svelte</span>
-						<p class="mt-0.5 text-xs text-neutral-400">
+						<span class="text-sm font-medium" style="color: var(--color-text)">Async Svelte</span>
+						<p class="mt-0.5 text-xs" style="color: var(--color-text-subtle)">
 							Updates the svelte.config.js file to support async svelte
 						</p>
 					</div>
 				</label>
-				<label
-					class="flex cursor-pointer items-start gap-3 rounded-lg p-3 transition-colors hover:bg-neutral-900/50"
-				>
-					<input
-						type="checkbox"
-						bind:checked={helloWorld}
-						class="mt-0.5 h-5 w-5 shrink-0 cursor-pointer rounded border-neutral-600 text-blue-500"
-					/>
+				<label class="option-row">
+					<input type="checkbox" bind:checked={helloWorld} class="option-checkbox" />
 					<div>
-						<span class="text-sm font-medium text-neutral-200">Hello World</span>
-						<p class="mt-0.5 text-xs text-neutral-400">
+						<span class="text-sm font-medium" style="color: var(--color-text)">Hello World</span>
+						<p class="mt-0.5 text-xs" style="color: var(--color-text-subtle)">
 							Makes the default page a nicer hello world
 						</p>
 					</div>
@@ -243,53 +207,41 @@
 		<!-- VSCode Theme -->
 		<div class="space-y-4">
 			<label class="flex cursor-pointer items-center gap-3">
-				<input
-					type="checkbox"
-					bind:checked={vscodeThemeEnabled}
-					class="h-4 w-4 cursor-pointer rounded border-neutral-600 text-blue-500"
-				/>
-				<span class="font-medium text-neutral-200">VSCode Theme</span>
+				<input type="checkbox" bind:checked={vscodeThemeEnabled} class="option-checkbox h-4 w-4" />
+				<span class="font-medium" style="color: var(--color-text)">VSCode Theme</span>
 			</label>
 			{#if vscodeThemeEnabled}
 				<div class="space-y-4 pl-7">
 					<div>
 						<label
 							for="topBarColor"
-							class="mb-3 block text-xs font-medium tracking-wide text-neutral-400 uppercase"
-							>Top Bar Color</label
+							class="mb-3 block text-xs font-medium tracking-wide uppercase"
+							style="color: var(--color-text-subtle)">Top Bar Color</label
 						>
 						<div class="flex items-center gap-3">
 							<input
 								type="color"
 								id="topBarColor"
 								bind:value={topBarColor}
-								class="h-8 w-12 cursor-pointer rounded border border-neutral-600"
+								class="field-input h-8 w-12 cursor-pointer p-0"
 							/>
-							<input
-								type="text"
-								bind:value={topBarColor}
-								class="flex-1 rounded border border-neutral-600 bg-neutral-900 px-3 py-2 font-mono text-xs text-neutral-200"
-							/>
+							<input type="text" bind:value={topBarColor} class="field-input flex-1" />
 						</div>
 					</div>
 					<div>
 						<label
 							for="topBarTextColor"
-							class="mb-3 block text-xs font-medium tracking-wide text-neutral-400 uppercase"
-							>Top Bar Text Color</label
+							class="mb-3 block text-xs font-medium tracking-wide uppercase"
+							style="color: var(--color-text-subtle)">Top Bar Text Color</label
 						>
 						<div class="flex items-center gap-3">
 							<input
 								type="color"
 								id="topBarTextColor"
 								bind:value={topBarTextColor}
-								class="h-8 w-12 cursor-pointer rounded border border-neutral-600"
+								class="field-input h-8 w-12 cursor-pointer p-0"
 							/>
-							<input
-								type="text"
-								bind:value={topBarTextColor}
-								class="flex-1 rounded border border-neutral-600 bg-neutral-900 px-3 py-2 font-mono text-xs text-neutral-200"
-							/>
+							<input type="text" bind:value={topBarTextColor} class="field-input flex-1" />
 						</div>
 					</div>
 				</div>
@@ -302,30 +254,26 @@
 				<input
 					type="checkbox"
 					bind:checked={tailwindThemeEnabled}
-					class="h-4 w-4 cursor-pointer rounded border-neutral-600 text-blue-500"
+					class="option-checkbox h-4 w-4"
 				/>
-				<span class="font-medium text-neutral-200">Tailwind Theme</span>
+				<span class="font-medium" style="color: var(--color-text)">Tailwind Theme</span>
 			</label>
 			{#if tailwindThemeEnabled}
 				<div class="space-y-4 pl-7">
 					<div>
 						<label
 							for="primaryColor"
-							class="mb-3 block text-xs font-medium tracking-wide text-neutral-400 uppercase"
-							>Primary Color</label
+							class="mb-3 block text-xs font-medium tracking-wide uppercase"
+							style="color: var(--color-text-subtle)">Primary Color</label
 						>
 						<div class="flex items-center gap-3">
 							<input
 								type="color"
 								id="primaryColor"
 								bind:value={primaryColor}
-								class="h-8 w-12 cursor-pointer rounded border border-neutral-600"
+								class="field-input h-8 w-12 cursor-pointer p-0"
 							/>
-							<input
-								type="text"
-								bind:value={primaryColor}
-								class="flex-1 rounded border border-neutral-600 bg-neutral-900 px-3 py-2 font-mono text-xs text-neutral-200"
-							/>
+							<input type="text" bind:value={primaryColor} class="field-input flex-1" />
 						</div>
 					</div>
 				</div>
@@ -334,11 +282,7 @@
 
 		<!-- Copy Button -->
 		<div class="flex justify-start pt-4">
-			<button
-				onclick={copyPrompts}
-				disabled={isLoading}
-				class="flex items-center gap-2 rounded-lg border-2 border-blue-500 bg-transparent px-4 py-2 font-medium text-blue-300 transition-all hover:border-blue-400 hover:text-blue-200 disabled:border-neutral-600 disabled:text-neutral-500"
-			>
+			<button onclick={copyPrompts} disabled={isLoading} class="button">
 				{#if isLoading}
 					<svg class="h-4 w-4 animate-spin" viewBox="0 0 24 24" fill="none">
 						<circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"
@@ -352,7 +296,7 @@
 					Copying...
 				{:else if copySuccess}
 					<svg
-						class="h-4 w-4 text-green-400"
+						class="success-text h-4 w-4"
 						viewBox="0 0 24 24"
 						fill="none"
 						stroke="currentColor"
@@ -371,11 +315,10 @@
 
 <!-- Toast Notification -->
 {#if toastMessage}
-	<div
-		class={`fixed right-8 bottom-8 z-50 flex items-center gap-3 rounded-xl border px-4 py-3 text-sm font-medium shadow-xl backdrop-blur-sm transition-all ${toastType === 'success' ? 'border-green-500/30 bg-green-500/10 text-green-500' : 'border-red-500/30 bg-red-500/10 text-red-500'}`}
-	>
+	<div class={`toast ${toastType === 'success' ? 'toast-success' : 'toast-error'}`}>
 		<div
-			class={`h-2 w-2 rounded-full ${toastType === 'success' ? 'bg-green-400' : 'bg-red-400'}`}
+			class="h-2 w-2"
+			style:background={toastType === 'success' ? 'var(--color-success)' : 'var(--color-danger)'}
 		></div>
 		{toastMessage}
 	</div>


### PR DESCRIPTION
## Summary
- add semantic palette tokens for the refined dark and warm light themes
- migrate homepage, utility pages, sponsor cards, keyboard visual, and controls onto shared design-system classes
- tone down interaction colors so cyan is focus/active, green is success, amber is rare emphasis, and violet stays contextual

## Tests
- bun run check
- bun run build
- bun run lint
- local Vite HTTP smoke test for /, /sponsors, /macos, /karabiner, /font, /sv, /og

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Apply refined design token system across site components and pages
> - Introduces a new CSS design token palette in [app.css](https://github.com/davis7dotsh/davis7dotsh/pull/10/files#diff-e269447b167c1d69748b9d5ccde405e2fb2d74af0d1832d5c05e63362816722d) with variables for backgrounds, surfaces, text, borders, focus, and accents for both dark and light themes.
> - Adds utility classes (`.surface`, `.resource-card`, `.button`, `.icon-button`, `.brand-link`, `.back-link`, `.toast`, etc.) used across all pages and components.
> - Updates the [Keyboard component](https://github.com/davis7dotsh/davis7dotsh/pull/10/files#diff-016c90d2641ab5be165608fcbfeaf0b4f9eaf7bc53401a4c0e1a7201e235942f) visuals: keys lose rounded corners, caps lock uses a warning color, and hover/active states use cyan accent blends via `color-mix`.
> - Migrates all pages to use the new token classes, removing hardcoded Tailwind neutral classes throughout.
> - Fixes the clipboard copy in [karabiner/+page.svelte](https://github.com/davis7dotsh/davis7dotsh/pull/10/files#diff-2344bebaa5718c9fb6e66a5fabc7f104b57f0b4e9622aa198008ea7c8745d32c) so 'Copied!' only shows on successful write; changes default `topBarColor` and `primaryColor` values in [sv/+page.svelte](https://github.com/davis7dotsh/davis7dotsh/pull/10/files#diff-9f709aaab950d340b970c8296853c6e07bfeddbf4b862b2da36867f9c2684c1d).
> - Behavioral Change: default colors for the SvelteKit setup page top bar (`#232831`) and primary color (`#00B8D9`) change for all users.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6bdf667.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Introduced semantic design tokens and palette variables for refined dark and warm light themes (semantic --color-* tokens, surfaces, text, borders, shadows, accents) and replaced hardcoded color values (src/app.css, src/app.html)
- Added shared UI utility classes and components styling hooks: .surface, .resource-card, .button, .icon-button, .back-link, .brand-link, .toast, .field-input, .option-row, .code-chip, .sponsor-card, etc., and standardized focus outlines (src/app.css)
- Migrated pages and components from Tailwind neutral utilities to the new design system:
  - Homepage: src/routes/+page.svelte (logo, headings, resource cards)
  - Utility pages: src/routes/font/+page.svelte, src/routes/karabiner/+page.svelte, src/routes/macos/+page.svelte, src/routes/sv/+page.svelte
  - Sponsors: src/routes/sponsors/+page.svelte (per-sponsor --sponsor-accent usage; removed per-theme gradient overrides)
  - OG image: src/routes/og/+page.svelte (background/grid/glow recolor and opacity tweaks)
  - Layout: src/routes/+layout.svelte (removed global text-neutral-50)
  - Components: src/lib/components/Keyboard.svelte (square-corner SVG keys, theme-variable fill/stroke, color-mix hover/active), ThemeToggle.svelte (delegated to icon-button)
- Behavior change: karabiner clipboard copy now uses async navigator.clipboard.writeText with success/failure handling and copy state reset (src/routes/karabiner/+page.svelte)
- Default SV page config updates: topBarColor → #232831; primaryColor → #00B8D9 (cyan accent) (src/routes/sv/+page.svelte)
- Tests and smoke checks performed locally: bun run check, bun run build, bun run lint, Vite HTTP smoke tests for /, /sponsors, /macos, /karabiner, /font, /sv, /og
- Notable issue discovered in review: Greptile flagged a P1 contrast problem for the Daytona sponsor card — --sponsor-accent currently resolves to var(--color-cloud) (#e5e7eb), producing near-invisible CTA text on a white surface in light mode. The prior explicit light-mode override was removed; reintroduce a light-safe accent or re-add the override for Daytona.
- No changes to authentication services or database schema/data models detected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR migrates the entire site from hardcoded Tailwind color utilities to a shared CSS custom-property design system, introducing semantic palette tokens for dark and warm-light themes alongside reusable utility classes (`.surface`, `.button`, `.icon-button`, `.resource-card`, etc.). The refactor is consistent across all 12 changed files with no functional regressions found. No plan `.md` files were committed.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all changes are visual/CSS refactoring with one minor P2 UX gap.

No P0 or P1 issues found. The only finding is a P2: the karabiner copy-to-clipboard error handler silently swallows failures with no user feedback. Everything else is a clean, consistent design-system migration.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/app.css | Adds semantic palette tokens and shared utility classes; no logic bugs found — straightforward CSS variable migration. |
| src/app.html | Inline pre-load styles updated to match new palette values; consistent with design token changes. |
| src/lib/components/Keyboard.svelte | Switched keycap fill/stroke from Tailwind classes to CSS variable expressions; rx changed from 6 to 0 (square corners). Visual-only change, no breakage. |
| src/lib/components/ThemeToggle.svelte | Replaced fully-custom Tailwind styling with icon-button class; hover effect changed from scale to translateY. Minor visual change, no logic issues. |
| src/routes/+layout.svelte | Removed text-neutral-50 default class; text color now delegated to component-level CSS variables. |
| src/routes/+page.svelte | Homepage migrated to resource-card, headline-text, brand-link classes; no functional regressions found. |
| src/routes/karabiner/+page.svelte | Styling migrated to design tokens; copy function made async with error handling; modal click propagation properly stopped. Minor: clipboard errors are silently swallowed. |
| src/routes/sponsors/+page.svelte | Sponsor cards refactored to single --sponsor-accent variable; light-mode Daytona override added to fix CTA contrast. |
| src/routes/sv/+page.svelte | SvelteKit setup page migrated to design tokens; default colors updated; toast styling moved to shared classes. |
| src/routes/og/+page.svelte | OG card background and text colors updated to match new palette; grid opacity reduced slightly. |
| src/routes/font/+page.svelte | Font page migrated to back-link and brand-link classes; image border moved to inline CSS variable. |
| src/routes/macos/+page.svelte | MacOS page copy buttons migrated to button class with success-text; no logic changes. |

</details>

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22davis7dotsh%2Fdavis7dotsh%22%20on%20the%20existing%20branch%20%22davis%2Fui-cleaning%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22davis%2Fui-cleaning%22.%0A%0AFix%20the%20following%201%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Asrc%2Froutes%2Fkarabiner%2F%2Bpage.svelte%3A698-708%0A**Silent%20clipboard%20error%20gives%20no%20user%20feedback**%0A%0AThe%20%60catch%60%20block%20sets%20%60copied%20%3D%20false%60%2C%20which%20is%20already%20its%20default%20state%2C%20so%20a%20clipboard%20permission%20denial%20or%20API%20error%20is%20completely%20invisible%20to%20the%20user.%20The%20%60sv%60%20page%20already%20has%20a%20toast%20notification%20system%20that%20could%20be%20reused%20here%2C%20or%20at%20minimum%20a%20console%20warning%20would%20help%20debugging.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: src/routes/karabiner/+page.svelte
Line: 698-708

Comment:
**Silent clipboard error gives no user feedback**

The `catch` block sets `copied = false`, which is already its default state, so a clipboard permission denial or API error is completely invisible to the user. The `sv` page already has a toast notification system that could be reused here, or at minimum a console warning would help debugging.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (2): Last reviewed commit: ["Address PR review feedback"](https://github.com/davis7dotsh/davis7dotsh/commit/6bdf6679a393799febb1a8587c6febe0f977d6e6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29679395)</sub>

<!-- /greptile_comment -->