### PR TITLE
Update homepage hero with primary social links

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
 	"type": "module",
 	"scripts": {
 		"dev": "vite dev",
-		"build": "vite build",
+		"build": "svelte-kit sync && vite build",
+		"prepare": "svelte-kit sync",
 		"preview": "vite preview",
 		"deploy": "vite build && wrangler deploy",
 		"check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",

--- a/src/lib/components/PrimarySocialLinks.svelte
+++ b/src/lib/components/PrimarySocialLinks.svelte
@@ -1,0 +1,116 @@
+<script lang="ts">
+	type Link = {
+		href: string;
+		label: string;
+		icon: 'youtube' | 'x' | 'twitch';
+	};
+
+	const links: Link[] = [
+		{
+			href: 'https://www.youtube.com/@bmdavis419',
+			label: 'bmdavis419',
+			icon: 'youtube'
+		},
+		{
+			href: 'https://www.youtube.com/@nerd-snipe',
+			label: 'nerd snipe',
+			icon: 'youtube'
+		},
+		{
+			href: 'https://x.com/davis7',
+			label: 'davis7',
+			icon: 'x'
+		},
+		{
+			href: 'https://www.twitch.tv/bmdavis419',
+			label: 'bmdavis419',
+			icon: 'twitch'
+		}
+	];
+</script>
+
+<nav class="primary-social-links" aria-label="social">
+	<ul class="primary-social-links__list">
+		{#each links as link (link.href)}
+			<li>
+				<a
+					href={link.href}
+					target="_blank"
+					rel="noopener noreferrer"
+					class="primary-social-link"
+				>
+					<span class="primary-social-link__icon" aria-hidden="true">
+						{#if link.icon === 'youtube'}
+							<svg viewBox="0 0 256 180" xmlns="http://www.w3.org/2000/svg">
+								<path
+									d="M250.346 28.075A32.18 32.18 0 0 0 227.69 5.418C207.824 0 127.87 0 127.87 0S47.912.164 28.046 5.582A32.18 32.18 0 0 0 5.39 28.24c-6.009 35.298-8.34 89.084.165 122.97a32.18 32.18 0 0 0 22.656 22.657c19.866 5.418 99.822 5.418 99.822 5.418s79.955 0 99.82-5.418a32.18 32.18 0 0 0 22.657-22.657c6.338-35.348 8.291-89.1-.164-123.134Z"
+									fill="currentColor"
+								/>
+								<path
+									fill="var(--youtube-play-color)"
+									d="m102.421 128.06 66.328-38.418-66.328-38.418z"
+								/>
+							</svg>
+						{:else if link.icon === 'x'}
+							<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 1227">
+								<path
+									fill="currentColor"
+									d="M714.163 519.284 1160.89 0h-105.86L667.137 450.887 357.328 0H0l468.492 681.821L0 1226.37h105.866l409.625-476.152 327.181 476.152H1200L714.137 519.284h.026ZM569.165 687.828l-47.468-67.894-377.686-540.24h162.604l304.797 435.991 47.468 67.894 396.2 566.721H892.476L569.165 687.854v-.026Z"
+								/>
+							</svg>
+						{:else}
+							<svg viewBox="0 0 256 268" xmlns="http://www.w3.org/2000/svg">
+								<path
+									fill="currentColor"
+									d="M17.458 0 0 46.556v186.201h63.983v34.934h34.931l34.898-34.934h52.36L256 162.954V0H17.458Zm23.259 23.263H232.73v128.029l-40.739 40.741H128L93.113 226.92v-34.886H40.717V23.263Zm64.008 116.405H128V69.844h-23.275v69.824Zm63.997 0h23.27V69.844h-23.27v69.824Z"
+								/>
+							</svg>
+						{/if}
+					</span>
+					<span class="primary-social-link__label">{link.label}</span>
+				</a>
+			</li>
+		{/each}
+	</ul>
+</nav>
+
+<style lang="postcss">
+	@reference 'tailwindcss';
+
+	.primary-social-links {
+		@apply mt-2 mb-6;
+	}
+
+	.primary-social-links__list {
+		@apply m-0 flex list-none flex-wrap items-center gap-x-5 gap-y-2 p-0;
+	}
+
+	.primary-social-link {
+		@apply inline-flex items-center gap-1.5 text-sm transition-colors;
+		color: var(--color-text-subtle);
+		text-decoration: none;
+		border-bottom: 1px solid transparent;
+	}
+
+	.primary-social-link:hover {
+		color: var(--color-link-hover);
+		border-bottom-color: var(--color-link-hover);
+	}
+
+	.primary-social-link:focus-visible {
+		outline: 1px solid var(--color-focus);
+		outline-offset: 3px;
+	}
+
+	.primary-social-link__icon {
+		@apply flex h-4 w-4 shrink-0 items-center justify-center;
+	}
+
+	.primary-social-link__icon :global(svg) {
+		@apply h-full w-full;
+	}
+
+	.primary-social-link__label {
+		@apply leading-none;
+	}
+</style>

--- a/src/lib/components/PrimarySocialLinks.svelte
+++ b/src/lib/components/PrimarySocialLinks.svelte
@@ -82,7 +82,7 @@
 	}
 
 	.primary-social-links__list {
-		@apply m-0 flex list-none flex-wrap items-center gap-x-5 gap-y-2 p-0;
+		@apply m-0 grid list-none grid-cols-2 gap-x-5 gap-y-3 p-0 sm:flex sm:flex-wrap sm:items-center sm:gap-y-2;
 	}
 
 	.primary-social-link {

--- a/src/lib/image.ts
+++ b/src/lib/image.ts
@@ -1,10 +1,10 @@
-import { dev } from '$app/environment';
+import { building, dev } from '$app/environment';
 
 const defaultWidths = [640, 828, 1200, 1920];
 const defaultQuality = 90;
 
 function shouldOptimize(src: string) {
-	return !dev && !src.endsWith('.svg');
+	return !dev && !building && !src.endsWith('.svg');
 }
 
 export function vercelImageUrl(src: string, width = 1200, quality = defaultQuality) {

--- a/src/lib/shiki-highlight.ts
+++ b/src/lib/shiki-highlight.ts
@@ -1,0 +1,23 @@
+import json from '@shikijs/langs/json';
+import githubDark from '@shikijs/themes/github-dark';
+import githubLight from '@shikijs/themes/github-light';
+import { createHighlighterCore } from 'shiki/core';
+import { createJavaScriptRegexEngine } from 'shiki/engine/javascript';
+
+type JsonTheme = 'github-dark' | 'github-light';
+
+let highlighterPromise: ReturnType<typeof createHighlighterCore> | null = null;
+
+function getHighlighter() {
+	highlighterPromise ??= createHighlighterCore({
+		themes: [githubDark, githubLight],
+		langs: [json],
+		engine: createJavaScriptRegexEngine()
+	});
+	return highlighterPromise;
+}
+
+export async function highlightJson(code: string, theme: JsonTheme) {
+	const highlighter = await getHighlighter();
+	return highlighter.codeToHtml(code, { lang: 'json', theme });
+}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import PrimarySocialLinks from '$lib/components/PrimarySocialLinks.svelte';
 	import SocialLinks from '$lib/components/SocialLinks.svelte';
 </script>
 
@@ -25,29 +26,8 @@
 				/>
 			</svg>
 		</div>
-		<h1 class="headline-text mb-0 pb-0 text-4xl font-bold tracking-tight">Ben Davis</h1>
-		<p class="muted-text mx-0 mt-2 mb-8">
-			<a
-				href="https://github.com/bmdavis419"
-				target="_blank"
-				rel="noopener noreferrer"
-				class="brand-link">developer</a
-			>,
-			<a
-				href="https://www.youtube.com/@bmdavis419"
-				target="_blank"
-				rel="noopener noreferrer"
-				class="brand-link">youtuber</a
-			>, and
-			<a
-				href="https://www.youtube.com/@t3dotgg/videos"
-				target="_blank"
-				rel="noopener noreferrer"
-				class="brand-link">theo's manager</a
-			>. based in sf.
-		</p>
-
-		<h3 class="headline-text mb-4 text-lg font-medium">You might be looking for:</h3>
+		<h1 class="headline-text mb-0 pb-0 text-[2.75rem] font-bold tracking-tight">Ben Davis</h1>
+		<PrimarySocialLinks />
 
 		<div class="home-link-list space-y-3">
 			<a href="/sponsors" class="resource-card">

--- a/src/routes/karabiner/+page.svelte
+++ b/src/routes/karabiner/+page.svelte
@@ -29,8 +29,9 @@
 		let cancelled = false;
 
 		(async () => {
+			const highlighted = await highlightJson(JSON.stringify(myConfig, null, 2), shikiTheme);
 			if (cancelled) return;
-			html = await highlightJson(JSON.stringify(myConfig, null, 2), shikiTheme);
+			html = highlighted;
 		})();
 
 		return () => {

--- a/src/routes/karabiner/+page.svelte
+++ b/src/routes/karabiner/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
-	import { codeToHtml } from 'shiki';
 	import { Copy, Check, X } from 'lucide-svelte';
 	import Keyboard from '$lib/components/Keyboard.svelte';
+	import { highlightJson } from '$lib/shiki-highlight';
 	import myConfig from './karabiner.json';
 	import { onMount } from 'svelte';
 
@@ -26,15 +26,16 @@
 
 	$effect(() => {
 		const shikiTheme = currentTheme === 'light' ? 'github-light' : 'github-dark';
-		const run = async () => {
-			const innerHtml = await codeToHtml(JSON.stringify(myConfig, null, 2), {
-				lang: 'json',
-				theme: shikiTheme
-			});
-			html = innerHtml;
-		};
+		let cancelled = false;
 
-		run();
+		(async () => {
+			if (cancelled) return;
+			html = await highlightJson(JSON.stringify(myConfig, null, 2), shikiTheme);
+		})();
+
+		return () => {
+			cancelled = true;
+		};
 	});
 
 	const copy = async () => {

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -16,12 +16,7 @@ const config = {
 				minimumCacheTTL: 300
 			}
 		}),
-		prerender: {
-			handleHttpError: ({ path, message }) => {
-				if (path === '/_vercel/image') return;
-				throw new Error(message);
-			}
-		},
+
 		experimental: {
 			remoteFunctions: true
 		}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,5 +3,17 @@ import tailwindcss from '@tailwindcss/vite';
 import { defineConfig } from 'vite';
 
 export default defineConfig({
-	plugins: [sveltekit(), tailwindcss()]
+	plugins: [sveltekit(), tailwindcss()],
+	build: {
+		rollupOptions: {
+			output: {
+				manualChunks(id) {
+					if (id.includes('node_modules/svelte/')) return 'svelte';
+					if (id.includes('node_modules/@shikijs/') || id.includes('node_modules/shiki/'))
+						return 'shiki';
+					if (id.includes('node_modules/marked')) return 'marked';
+				}
+			}
+		}
+	}
 });


### PR DESCRIPTION
## Summary

- Replaces the developer / youtuber / manager bio line with a horizontal row of social links (icon + label) for YouTube, Nerd Snipe, X, and Twitch
- Adds `PrimarySocialLinks` component styled to match the site
- Removes the "You might be looking for:" section heading; resource cards follow directly under the social links

## Test plan

- [ ] Verify homepage layout in dark and light themes
- [ ] Confirm all four social links open the correct URLs
- [ ] Check spacing between hero, social links, and resource cards on mobile and desktop

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add primary social links to homepage hero
> - Adds a new [`PrimarySocialLinks`](https://github.com/davis7dotsh/davis7dotsh/pull/15/files#diff-e7a755b783bc2a28fc12801968a107eaa74fa66f048aef8f70baca79351e6c7a) component rendering YouTube, X, and Twitch links with SVG icons and hover/focus styles, displayed below the main heading on the [home page](https://github.com/davis7dotsh/davis7dotsh/pull/15/files#diff-1e1270da740e81dd13f8a65057582b0fce8a5fb3817ef913f3e90d7f82c4e9df).
> - Removes the previous descriptive paragraph and 'You might be looking for:' subheading from the home page.
> - Extracts a [`highlightJson`](https://github.com/davis7dotsh/davis7dotsh/pull/15/files#diff-fee9823106485d0fad28c67b1d2bb097255522cf1f33397596a75f0dc157a9a3) helper that lazily initializes Shiki with GitHub themes, used by the [Karabiner page](https://github.com/davis7dotsh/davis7dotsh/pull/15/files#diff-2344bebaa5718c9fb6e66a5fabc7f104b57f0b4e9622aa198008ea7c8745d32c) instead of importing Shiki directly.
> - Adds Rollup `manualChunks` in [vite.config.ts](https://github.com/davis7dotsh/davis7dotsh/pull/15/files#diff-6a3b01ba97829c9566ef2d8dc466ffcffb4bdac08706d3d6319e42e0aa6890dd) to split `svelte`, `shiki`, and `marked` into separate vendor chunks.
> - Behavioral Change: `shouldOptimize` in [image.ts](https://github.com/davis7dotsh/davis7dotsh/pull/15/files#diff-7946f56a4ae59adab61a9e20a5a12ec529cd2679e0bb713c2190fc64c1f42418) now returns false during the build phase; prerender HTTP error handling reverts to SvelteKit's default after removing the custom handler from [svelte.config.js](https://github.com/davis7dotsh/davis7dotsh/pull/15/files#diff-6317e218ea40a2a9b47af98e100e81c06f9c0abff66737e6ca06ec4b29402242).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 45fc6fa.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- New component: src/lib/components/PrimarySocialLinks.svelte
  - Renders a horizontal nav of four primary social/profile links (YouTube, Nerd Snipe, X, Twitch) with icon + label
  - Typed links array (href, label, icon discriminator); conditional inline SVGs
  - Links open in new tab with target="_blank" and rel="noopener noreferrer"
  - Tailwind/PostCSS styles for layout, hover/focus, responsive sizing
  - +116 lines

- Homepage change: src/routes/+page.svelte
  - Imports and renders PrimarySocialLinks directly under the H1
  - Removes the prior bio line (“developer / youtuber / manager”) and removes the “You might be looking for:” heading so resource cards follow immediately
  - H1 font-size changed to text-[2.75rem]
  - +3 / -23 lines

- Shiki/highlighting
  - Added src/lib/shiki-highlight.ts: singleton/lazy Shiki highlighter and exported async highlightJson(code, theme)
  - Updated src/routes/karabiner/+page.svelte to use highlightJson and added async effect cancellation to avoid stale highlights

- Build/config and utilities
  - vite.config.ts: added manual Rollup chunk splitting for svelte, shiki, and marked
  - package.json: updated scripts (svelte-kit sync added to build/prepare)
  - svelte.config.js: removed custom kit.prerender handleHttpError block (Vercel/prerender-related adjustment)
  - src/lib/image.ts: broadened shouldOptimize to also skip optimization during build time (affects vercel image helpers)

- Misc / fixes
  - Commit: "Ignore stale Shiki highlights after theme changes" — adds effect-cancellation check so slower highlight runs don’t overwrite newer theme changes
  - Test plan: verify homepage layout in light/dark, ensure all four links open correct URLs, check spacing between hero, social links, and resource cards on mobile/desktop

- Security / data model note
  - This PR does not touch authentication service implementations or database schema/data models.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates the homepage hero and related build helpers. It changes:
- Adds a `PrimarySocialLinks` component for YouTube, Nerd Snipe, X, and Twitch links.
- Places the social links under the homepage heading and removes the old bio line.
- Updates Karabiner JSON highlighting to use a shared Shiki helper.
- Adjusts image optimization and Vite chunking for build behavior.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Checked the homepage social links for the expected four destinations: YouTube, Nerd Snipe, X, and Twitch.
- Reviewed the responsive social link layout classes for mobile and desktop spacing.
- Checked the light and dark theme styling paths through the component CSS variables.
- Checked the Karabiner JSON highlighting path, including the theme-change cancellation guard.
- Checked the image optimization build guard and related prerender config change.
- Observed that the local build could not complete in the sandbox because the available Node.js version was older than the project requirement.

<details open><summary><strong>Artifacts</strong></summary><br />

**[Targeted validation checks for homepage links, layout, theme styling, image optimization, config, and Karabiner highlighting](https://app.greptile.com/trex/artifacts/1ef4e2a9-9b78-4f23-932c-a20313c5c71d)**

- This log captures the targeted validation checks performed on homepage links, responsive layout, theme styling, image optimization, config and Karabiner highlighting.
</details>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (3): Last reviewed commit: ["Ignore stale Shiki highlights after them..."](https://github.com/davis7dotsh/davis7dotsh/commit/45fc6fa424f44efc205216cf93fba0d2beb46b8b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35190990)</sub>

<!-- /greptile_comment -->