### PR TITLE
Add Conductor repo settings

### DIFF
--- a/.conductor/settings.toml
+++ b/.conductor/settings.toml
@@ -1,0 +1,12 @@
+"$schema" = "https://conductor.build/schemas/settings.repo.schema.json"
+
+[scripts]
+# Install deps with pnpm (the project's package manager). pnpm's `prepare`
+# lifecycle runs `svelte-kit sync` automatically, generating ./.svelte-kit.
+setup = "pnpm install"
+
+# SvelteKit dev server. Each workspace gets its own port via CONDUCTOR_PORT.
+run = "pnpm dev --port $CONDUCTOR_PORT"
+
+# No fixed port, database, or Docker stack — workspaces run side by side.
+run_mode = "concurrent"


### PR DESCRIPTION
Adds a shared `.conductor/settings.toml` so teammates get a consistent Conductor workspace setup for this SvelteKit + pnpm project. The `setup` script runs `pnpm install` (which triggers `svelte-kit sync` via pnpm's `prepare` lifecycle), and the `run` script starts the dev server on the workspace's `CONDUCTOR_PORT`. `run_mode = "concurrent"` is safe because the app has no fixed port, database, or Docker stack, so workspaces can run side by side. The file is stamped with the repo settings schema and validated against it.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Conductor repo settings for setup and dev server scripts
> Adds [.conductor/settings.toml](https://github.com/davis7dotsh/davis7dotsh/pull/22/files#diff-4b80b61eb68fb8b2f1ba3b89144edc13907180d698e0134ce05dd7436a7247d8) to configure Conductor for this repo. The `setup` script runs `pnpm install`, `run` starts the dev server on `$CONDUCTOR_PORT`, and `run_mode` is set to `concurrent` to support parallel workspace execution.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a580806.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

- Adds `.conductor/settings.toml` with the Conductor repo settings schema.
- Defines a setup script that runs `pnpm install`.
- Defines a run script that starts Vite on `CONDUCTOR_PORT`.
- Enables concurrent Conductor run mode for side-by-side workspaces.

<h3>Confidence Score: 4/5</h3>

The repo settings change needs attention before merge because the setup command can fail in workspaces that start with an incompatible Node runtime.

The change is small and localized, and the compatibility issue is straightforward to validate against the configured setup command.

`.conductor/settings.toml`

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Reproduced the Conductor setup failure when running the repository's pinned pnpm install under Node v20.9.0; pnpm warned that Node.js v22.13 is required and the process aborted with a node:util styleText SyntaxError.
- Verified conductor setup progress by inspecting the post-setup state, including the after-state that shows head settings with scripts.setup=pnpm install and the prepare step completing, along with generated .svelte-kit files.
- Started two concurrent conductor dev servers and confirmed both responded successfully, serving on ports 41731 and 41732 with HTTP 200, as reported by the Vite logs.
- Validated conductor settings by retrieving the remote schema and confirming a PASS with SCHEMA\_HTTP\_STATUS 200 OK, and an exit code of 0.

<a href="https://app.greptile.com/trex/runs/11456737/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1" height="32"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22davis7dotsh%2Fdavis7dotsh%22%20on%20the%20existing%20branch%20%22bmdavis419%2Fconductor-settings-toml%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22bmdavis419%2Fconductor-settings-toml%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0A.conductor%2Fsettings.toml%3A6%0A**Pin%20Node%20version**%20This%20setup%20script%20can%20fail%20before%20installing%20dependencies%20unless%20the%20workspace%20already%20has%20a%20compatible%20Node%20version.%20The%20repo%20pins%20%60pnpm%4011.5.2%60%2C%20which%20requires%20a%20newer%20Node%20runtime%20than%20older%2Fdefault%20installs%3B%20in%20a%20Node%2020%20workspace%2C%20%60pnpm%20install%60%20can%20fail%20before%20dependencies%20install%20and%20before%20%60svelte-kit%20sync%60%20runs.%20Add%20a%20repo-level%20Node%20version%20or%20make%20the%20Conductor%20setup%20select%2Factivate%20a%20compatible%20Node%20version%20before%20running%20%60pnpm%20install%60.%0A%0A&repo=davis7dotsh%2Fdavis7dotsh&pr=22&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
.conductor/settings.toml:6
**Pin Node version** This setup script can fail before installing dependencies unless the workspace already has a compatible Node version. The repo pins `pnpm@11.5.2`, which requires a newer Node runtime than older/default installs; in a Node 20 workspace, `pnpm install` can fail before dependencies install and before `svelte-kit sync` runs. Add a repo-level Node version or make the Conductor setup select/activate a compatible Node version before running `pnpm install`.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Add Conductor repo settings"](https://github.com/davis7dotsh/davis7dotsh/commit/a580806f478e39df4b7fe041f1514239798d0b77) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38264206)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->